### PR TITLE
リバーシ盤をモデルとビューに分離

### DIFF
--- a/Reversi.xcodeproj/project.pbxproj
+++ b/Reversi.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		50182BFA2455C68600BDC2B6 /* BoardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50182BF92455C68600BDC2B6 /* BoardTests.swift */; };
 		503FF3FA2453123900D944A8 /* Board.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503FF3F92453123900D944A8 /* Board.swift */; };
 		D636B39F23D35043007F370F /* DiskView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D636B39E23D35043007F370F /* DiskView.swift */; };
 		D642BDB423A9FE4500396732 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D642BDB323A9FE4500396732 /* AppDelegate.swift */; };
@@ -32,6 +33,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		50182BF92455C68600BDC2B6 /* BoardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardTests.swift; sourceTree = "<group>"; };
 		503FF3F92453123900D944A8 /* Board.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Board.swift; sourceTree = "<group>"; };
 		D636B39E23D35043007F370F /* DiskView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskView.swift; sourceTree = "<group>"; };
 		D642BDB023A9FE4500396732 /* Reversi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Reversi.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -125,6 +127,7 @@
 			isa = PBXGroup;
 			children = (
 				D642BDCA23A9FE4700396732 /* ReversiTests.swift */,
+				50182BF92455C68600BDC2B6 /* BoardTests.swift */,
 				D642BDCC23A9FE4700396732 /* Info.plist */,
 			);
 			path = ReversiTests;
@@ -246,6 +249,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				50182BFA2455C68600BDC2B6 /* BoardTests.swift in Sources */,
 				D642BDCB23A9FE4700396732 /* ReversiTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Reversi.xcodeproj/project.pbxproj
+++ b/Reversi.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		D636B3A423D432D3007F370F /* DataTypes */ = {
 			isa = PBXGroup;
 			children = (
+				503FF3F92453123900D944A8 /* Board.swift */,
 				D642BDD723AA0B5700396732 /* Disk.swift */,
 			);
 			name = DataTypes;
@@ -110,7 +111,6 @@
 				D642BDB323A9FE4500396732 /* AppDelegate.swift */,
 				D642BDB523A9FE4500396732 /* SceneDelegate.swift */,
 				D642BDB723A9FE4500396732 /* ViewController.swift */,
-				503FF3F92453123900D944A8 /* Board.swift */,
 				D642BDB923A9FE4500396732 /* Main.storyboard */,
 				D642BDBC23A9FE4700396732 /* Assets.xcassets */,
 				D642BDBE23A9FE4700396732 /* LaunchScreen.storyboard */,

--- a/Reversi/Board.swift
+++ b/Reversi/Board.swift
@@ -42,6 +42,15 @@ public struct Board {
         xRange = 0 ..< width
         yRange = 0 ..< height
         cells = [Disk?].init(repeating: nil, count: width * height)
+        _ = reset()
+    }
+    
+    /// `dump()` で書き出した配列を元に、盤の状態を構築します。
+    /// - Parameter dump: 盤の状態を書き出した配列
+    /// - Throws: 引数で渡されたものが不正な場合は `BoardError.restore` を `throw` します。
+    public init(restoringFrom dump: [[Disk?]]) throws {
+        self.init()
+        _ = try restore(from: dump)
     }
     
     /// 盤をゲーム開始時に状態に戻します。

--- a/Reversi/Board.swift
+++ b/Reversi/Board.swift
@@ -19,7 +19,7 @@ public struct Board {
     public let yRange: Range<Int>
     
     /// 状態が変更されたセルの場所と変更後のディスクの値を示します。
-    public struct CellChange {
+    public struct CellChange: Hashable {
         /// 変更されたセルの列です。
         public var x: Int
         

--- a/Reversi/Board.swift
+++ b/Reversi/Board.swift
@@ -1,33 +1,44 @@
 import Foundation
 
-enum BoardError: Error {
+public enum BoardError: Error {
     case diskPlacement(disk: Disk, x: Int, y: Int)
     case restore(dump: [[Disk?]])
 }
 
-struct Board {
+public struct Board {
     /// 盤の幅（ `8` ）を表します。
-    let width: Int = 8
+    public let width: Int = 8
     
     /// 盤の高さ（ `8` ）を返します。
-    let height: Int = 8
+    public let height: Int = 8
     
     /// 盤のセルの `x` の範囲（ `0 ..< 8` ）を返します。
-    let xRange: Range<Int>
+    public let xRange: Range<Int>
     
     /// 盤のセルの `y` の範囲（ `0 ..< 8` ）を返します。
-    let yRange: Range<Int>
+    public let yRange: Range<Int>
     
     /// 状態が変更されたセルの場所と変更後のディスクの値を示します。
-    struct CellChange {
-        var x: Int
-        var y: Int
-        var disk: Disk?
+    public struct CellChange {
+        /// 変更されたセルの列です。
+        public var x: Int
+        
+        /// 変更されたセルの行です。
+        public var y: Int
+        
+        /// 変更された結果のセルの状態です。セルにディスクが置かれていない場合、 `nil` になります。
+        public var disk: Disk?
+        
+        public init(x: Int, y: Int, disk: Disk?) {
+            self.x = x
+            self.y = y
+            self.disk = disk
+        }
     }
     
     private var cells: [Disk?]
 
-    init() {
+    public init() {
         xRange = 0 ..< width
         yRange = 0 ..< height
         cells = [Disk?].init(repeating: nil, count: width * height)
@@ -35,7 +46,7 @@ struct Board {
     
     /// 盤をゲーム開始時に状態に戻します。
     /// - Returns: 変更されたセルの情報を返します。
-    mutating func reset() -> [CellChange] {
+    public mutating func reset() -> [CellChange] {
         var cellChanges = [CellChange]()
         
         for y in  yRange {
@@ -52,9 +63,9 @@ struct Board {
         return cellChanges
     }
     
-    /// 盤の状態を `Disk?` の二次元配列に書き出します。
+    /// 盤の状態を `Disk?` の配列の配列に書き出します。
     /// - Returns: 盤の状態を書き出した配列
-    func dump() -> [[Disk?]] {
+    public func dump() -> [[Disk?]] {
         var output = [[Disk?]]()
         for y in yRange {
             var line = [Disk?]()
@@ -67,10 +78,10 @@ struct Board {
     }
     
     /// `dump()` で書き出した配列を元に、盤の状態を復元します。
-    /// - Parameter dumpedText: 盤の状態を書き出した文字列
+    /// - Parameter dump: 盤の状態を書き出した配列
     /// - Returns: 変更されたセルの情報を返します。
-    /// - Throws: 引数で渡された文字列が不正な場合は `BoardError.restore` を `throw` します。
-    mutating func restore(from dump: [[Disk?]]) throws -> [CellChange] {
+    /// - Throws: 引数で渡されたものが不正な場合は `BoardError.restore` を `throw` します。
+    public mutating func restore(from dump: [[Disk?]]) throws -> [CellChange] {
         var lines = dump[...]
 
         guard lines.count == height else {
@@ -103,7 +114,7 @@ struct Board {
     /// - Parameter x: セルの列です。
     /// - Parameter y: セルの行です。
     /// - Returns: セルにディスクが置かれている場合はそのディスクの値を、置かれていない場合は `nil` を返します。
-    func diskAt(x: Int, y: Int) -> Disk? {
+    public func diskAt(x: Int, y: Int) -> Disk? {
         guard xRange.contains(x) && yRange.contains(y) else { return nil }
         return cells[y * width + x]
     }
@@ -122,7 +133,7 @@ struct Board {
     /// `side` で指定された色のディスクが盤上に置かれている枚数を返します。
     /// - Parameter side: 数えるディスクの色です。
     /// - Returns: `side` で指定された色のディスクの、盤上の枚数です。
-    func countDisks(of side: Disk) -> Int {
+    public func countDisks(of side: Disk) -> Int {
         var count = 0
         
         for y in yRange {
@@ -139,7 +150,7 @@ struct Board {
     /// 盤上に置かれたディスクの枚数が多い方の色を返します。
     /// 引き分けの場合は `nil` が返されます。
     /// - Returns: 盤上に置かれたディスクの枚数が多い方の色です。引き分けの場合は `nil` を返します。
-    func sideWithMoreDisks() -> Disk? {
+    public func sideWithMoreDisks() -> Disk? {
         let darkCount = countDisks(of: .dark)
         let lightCount = countDisks(of: .light)
         if darkCount == lightCount {
@@ -196,13 +207,13 @@ struct Board {
     /// - Parameter x: セルの列です。
     /// - Parameter y: セルの行です。
     /// - Returns: 指定されたセルに `disk` を置ける場合は `true` を、置けない場合は `false` を返します。
-    func canPlaceDisk(_ disk: Disk, atX x: Int, y: Int) -> Bool {
+    public func canPlaceDisk(_ disk: Disk, atX x: Int, y: Int) -> Bool {
         !flippedDiskCoordinatesByPlacingDisk(disk, atX: x, y: y).isEmpty
     }
     
     /// `side` で指定された色のディスクを置ける盤上のセルの座標をすべて返します。
     /// - Returns: `side` で指定された色のディスクを置ける盤上のすべてのセルの座標の配列です。
-    func validMoves(for side: Disk) -> [(x: Int, y: Int)] {
+    public func validMoves(for side: Disk) -> [(x: Int, y: Int)] {
         var coordinates: [(Int, Int)] = []
         
         for y in yRange {
@@ -222,7 +233,7 @@ struct Board {
     /// - Parameter y: セルの行です。
     /// - Returns: 変更されたセルの情報を返します。
     /// - Throws: もし `disk` を `x`, `y` で指定されるセルに置けない場合、 `BoardError.diskPlacement` を `throw` します。
-    mutating func placeDisk(_ disk: Disk, atX x: Int, y: Int) throws -> [CellChange] {
+    public mutating func placeDisk(_ disk: Disk, atX x: Int, y: Int) throws -> [CellChange] {
         let diskCoordinates = flippedDiskCoordinatesByPlacingDisk(disk, atX: x, y: y)
         if diskCoordinates.isEmpty {
             throw BoardError.diskPlacement(disk: disk, x: x, y: y)

--- a/ReversiTests/BoardTests.swift
+++ b/ReversiTests/BoardTests.swift
@@ -1,0 +1,348 @@
+import XCTest
+@testable import Reversi
+
+class BoardTests: XCTestCase {
+    override func setUp() {
+    }
+
+    override func tearDown() {
+    }
+
+    func testJustInit() {
+        let board = Board()
+        XCTAssertEqual(board.dumpAsText(), """
+            --------
+            --------
+            --------
+            ---ox---
+            ---xo---
+            --------
+            --------
+            --------
+            """
+        )
+    }
+    
+    func testInitRestoring() throws {
+        let board = try Board(restoringFromText: """
+            o-------
+            -o-o----
+            --oo-o--
+            --xoxox-
+            ---xox--
+            ---oxxx-
+            ---o-x--
+            --o-----
+            """
+        )
+        
+        XCTAssertEqual(board.dumpAsText(), """
+            o-------
+            -o-o----
+            --oo-o--
+            --xoxox-
+            ---xox--
+            ---oxxx-
+            ---o-x--
+            --o-----
+            """
+        )
+    }
+
+    func testDiskAt() throws {
+        let board = try Board(restoringFromText: """
+            o-------
+            -o-o----
+            --oo-o--
+            --xoxox-
+            ---xox--
+            ---oxxx-
+            ---o-x--
+            --o-----
+            """
+        )
+        
+        XCTAssertEqual(board.diskAt(x: 3, y: 1), .light)
+        XCTAssertEqual(board.diskAt(x: 6, y: 3), .dark)
+        XCTAssertEqual(board.diskAt(x: 7, y: 7), nil)
+    }
+    
+    func testReset() throws {
+        var board = try Board(restoringFromText: """
+            o-------
+            -o-o----
+            --oo-o--
+            --xoxox-
+            ---xox--
+            ---oxxx-
+            ---o-x--
+            --o-----
+            """
+        )
+        
+        let cellChanges = board.reset()
+        XCTAssertEqual(cellChanges, [
+            // Clear all cells
+            Board.CellChange(x: 0, y: 0, disk: nil),
+            Board.CellChange(x: 1, y: 0, disk: nil),
+            Board.CellChange(x: 2, y: 0, disk: nil),
+            Board.CellChange(x: 3, y: 0, disk: nil),
+            Board.CellChange(x: 4, y: 0, disk: nil),
+            Board.CellChange(x: 5, y: 0, disk: nil),
+            Board.CellChange(x: 6, y: 0, disk: nil),
+            Board.CellChange(x: 7, y: 0, disk: nil),
+            Board.CellChange(x: 0, y: 1, disk: nil),
+            Board.CellChange(x: 1, y: 1, disk: nil),
+            Board.CellChange(x: 2, y: 1, disk: nil),
+            Board.CellChange(x: 3, y: 1, disk: nil),
+            Board.CellChange(x: 4, y: 1, disk: nil),
+            Board.CellChange(x: 5, y: 1, disk: nil),
+            Board.CellChange(x: 6, y: 1, disk: nil),
+            Board.CellChange(x: 7, y: 1, disk: nil),
+            Board.CellChange(x: 0, y: 2, disk: nil),
+            Board.CellChange(x: 1, y: 2, disk: nil),
+            Board.CellChange(x: 2, y: 2, disk: nil),
+            Board.CellChange(x: 3, y: 2, disk: nil),
+            Board.CellChange(x: 4, y: 2, disk: nil),
+            Board.CellChange(x: 5, y: 2, disk: nil),
+            Board.CellChange(x: 6, y: 2, disk: nil),
+            Board.CellChange(x: 7, y: 2, disk: nil),
+            Board.CellChange(x: 0, y: 3, disk: nil),
+            Board.CellChange(x: 1, y: 3, disk: nil),
+            Board.CellChange(x: 2, y: 3, disk: nil),
+            Board.CellChange(x: 3, y: 3, disk: nil),
+            Board.CellChange(x: 4, y: 3, disk: nil),
+            Board.CellChange(x: 5, y: 3, disk: nil),
+            Board.CellChange(x: 6, y: 3, disk: nil),
+            Board.CellChange(x: 7, y: 3, disk: nil),
+            Board.CellChange(x: 0, y: 4, disk: nil),
+            Board.CellChange(x: 1, y: 4, disk: nil),
+            Board.CellChange(x: 2, y: 4, disk: nil),
+            Board.CellChange(x: 3, y: 4, disk: nil),
+            Board.CellChange(x: 4, y: 4, disk: nil),
+            Board.CellChange(x: 5, y: 4, disk: nil),
+            Board.CellChange(x: 6, y: 4, disk: nil),
+            Board.CellChange(x: 7, y: 4, disk: nil),
+            Board.CellChange(x: 0, y: 5, disk: nil),
+            Board.CellChange(x: 1, y: 5, disk: nil),
+            Board.CellChange(x: 2, y: 5, disk: nil),
+            Board.CellChange(x: 3, y: 5, disk: nil),
+            Board.CellChange(x: 4, y: 5, disk: nil),
+            Board.CellChange(x: 5, y: 5, disk: nil),
+            Board.CellChange(x: 6, y: 5, disk: nil),
+            Board.CellChange(x: 7, y: 5, disk: nil),
+            Board.CellChange(x: 0, y: 6, disk: nil),
+            Board.CellChange(x: 1, y: 6, disk: nil),
+            Board.CellChange(x: 2, y: 6, disk: nil),
+            Board.CellChange(x: 3, y: 6, disk: nil),
+            Board.CellChange(x: 4, y: 6, disk: nil),
+            Board.CellChange(x: 5, y: 6, disk: nil),
+            Board.CellChange(x: 6, y: 6, disk: nil),
+            Board.CellChange(x: 7, y: 6, disk: nil),
+            Board.CellChange(x: 0, y: 7, disk: nil),
+            Board.CellChange(x: 1, y: 7, disk: nil),
+            Board.CellChange(x: 2, y: 7, disk: nil),
+            Board.CellChange(x: 3, y: 7, disk: nil),
+            Board.CellChange(x: 4, y: 7, disk: nil),
+            Board.CellChange(x: 5, y: 7, disk: nil),
+            Board.CellChange(x: 6, y: 7, disk: nil),
+            Board.CellChange(x: 7, y: 7, disk: nil),
+            
+            // Place initial disks
+            Board.CellChange(x: 3, y: 3, disk: .light),
+            Board.CellChange(x: 4, y: 3, disk: .dark),
+            Board.CellChange(x: 3, y: 4, disk: .dark),
+            Board.CellChange(x: 4, y: 4, disk: .light),
+        ])
+        
+        XCTAssertEqual(board.dumpAsText(), """
+            --------
+            --------
+            --------
+            ---ox---
+            ---xo---
+            --------
+            --------
+            --------
+            """
+        )
+    }
+    
+    func testPlaceDisk() throws {
+        var board = try Board(restoringFromText: """
+            o-------
+            -o-o----
+            --oo-o--
+            --xoxox-
+            ---xox--
+            ---oxxx-
+            ---o-x--
+            --o-----
+            """
+        )
+
+        let cellChangesLight = try board.placeDisk(.light, atX: 2, y: 5)
+        XCTAssertEqual(cellChangesLight, [
+            Board.CellChange(x: 2, y: 5, disk: .light),
+            Board.CellChange(x: 3, y: 4, disk: .light),
+            Board.CellChange(x: 4, y: 3, disk: .light),
+        ])
+        XCTAssertEqual(board.dumpAsText(), """
+            o-------
+            -o-o----
+            --oo-o--
+            --xooox-
+            ---oox--
+            --ooxxx-
+            ---o-x--
+            --o-----
+            """
+        )
+        
+        let cellChangesDark = try board.placeDisk(.dark, atX: 2, y: 1)
+        XCTAssertEqual(cellChangesDark, [
+            Board.CellChange(x: 2, y: 1, disk: .dark),
+            Board.CellChange(x: 3, y: 2, disk: .dark),
+            Board.CellChange(x: 4, y: 3, disk: .dark),
+            Board.CellChange(x: 2, y: 2, disk: .dark),
+        ])
+        XCTAssertEqual(board.dumpAsText(), """
+            o-------
+            -oxo----
+            --xx-o--
+            --xoxox-
+            ---oox--
+            --ooxxx-
+            ---o-x--
+            --o-----
+            """
+        )
+    }
+    
+    func testCountDisks() throws {
+        let board = try Board(restoringFromText: """
+            o-------
+            -o-o----
+            --oo-o--
+            --xoxox-
+            ---xox--
+            ---oxxx-
+            ---o-x--
+            --o-----
+            """
+        )
+        
+        XCTAssertEqual(board.countDisks(of: .light), 12)
+        XCTAssertEqual(board.countDisks(of: .dark), 9)
+    }
+    
+    func testSideWithMoreDisks() throws {
+        var board = try Board(restoringFromText: """
+            o-------
+            -o-o----
+            --oo-o--
+            --xoxox-
+            ---xox--
+            ---oxxx-
+            ---o-x--
+            --o-----
+            """
+        )
+        
+        XCTAssertEqual(board.sideWithMoreDisks(), .light)
+        
+        _ = board.reset()
+        XCTAssertEqual(board.sideWithMoreDisks(), nil)
+    }
+    
+    func testCanPlaceDisk() throws {
+        let board = try Board(restoringFromText: """
+            o-------
+            -o-o----
+            --oo-o--
+            --xoxox-
+            ---xox--
+            ---oxxx-
+            ---o-x--
+            --o-----
+            """
+        )
+        
+        XCTAssertTrue(board.canPlaceDisk(.light, atX: 4, y: 2))
+        XCTAssertFalse(board.canPlaceDisk(.dark, atX: 4, y: 2))
+        XCTAssertTrue(board.canPlaceDisk(.dark, atX: 3, y: 7))
+        XCTAssertFalse(board.canPlaceDisk(.light, atX: 5, y: 3))
+    }
+    
+    func testValidMoves() throws {
+        let board = try Board(restoringFromText: """
+            o-------
+            -o-o----
+            --oo-o--
+            --xoxox-
+            ---xox--
+            ---oxxx-
+            ---o-x--
+            --o-----
+            """
+        )
+
+        XCTAssertEqual(board.validMoves(for: .light).map { $0.0 * 10 + $0.1 }, [
+            42, 72,
+            13, 73,
+            14, 24, 64, 74,
+            25, 75,
+            46, 66, 76,
+            57,
+        ])
+    }
+}
+
+extension Board { // for testing
+    func dumpAsText() -> String {
+        return dump()
+            .map { dumpLine in
+                return dumpLine
+                    .map { $0.symbol }
+                    .joined()
+            }
+            .joined(separator: "\n")
+    }
+    
+    init(restoringFromText dumpText: String) throws {
+        let dumpArray = dumpText
+            .split(separator: "\n")
+            .map { line in
+                return line.map { character in
+                    return Disk?(symbol: "\(character)").flatMap { $0 }
+                }
+            }
+        try self.init(restoringFrom: dumpArray)
+    }
+}
+
+extension Optional where Wrapped == Disk {
+    fileprivate init?<S: StringProtocol>(symbol: S) {
+        switch symbol {
+        case "x":
+            self = .some(.dark)
+        case "o":
+            self = .some(.light)
+        case "-":
+            self = .none
+        default:
+            return nil
+        }
+    }
+    
+    fileprivate var symbol: String {
+        switch self {
+        case .some(.dark):
+            return "x"
+        case .some(.light):
+            return "o"
+        case .none:
+            return "-"
+        }
+    }
+}

--- a/ReversiTests/BoardTests.swift
+++ b/ReversiTests/BoardTests.swift
@@ -168,6 +168,137 @@ class BoardTests: XCTestCase {
         )
     }
     
+    func testRestore() throws {
+        let dump: [[Disk?]] = [
+            [.light, nil, nil, nil, nil, nil, nil, nil],
+            [nil, .light, nil, .light, nil, nil, nil, nil],
+            [nil, nil, .light, .light, nil, .light, nil, nil],
+            [nil, nil, .dark, .light, .dark, .light, .dark, nil],
+            [nil, nil, nil, .dark, .light, .dark, nil, nil],
+            [nil, nil, nil, .light, .dark, .dark, .dark, nil],
+            [nil, nil, nil, .light, nil, .dark, nil, nil],
+            [nil, nil, .light, nil, nil, nil, nil, nil],
+        ]
+        
+        var board = Board()
+        let cellChanges = try board.restore(from: dump)
+
+        XCTAssertEqual(cellChanges, [
+            Board.CellChange(x: 0, y: 0, disk: .light),
+            Board.CellChange(x: 1, y: 0, disk: nil),
+            Board.CellChange(x: 2, y: 0, disk: nil),
+            Board.CellChange(x: 3, y: 0, disk: nil),
+            Board.CellChange(x: 4, y: 0, disk: nil),
+            Board.CellChange(x: 5, y: 0, disk: nil),
+            Board.CellChange(x: 6, y: 0, disk: nil),
+            Board.CellChange(x: 7, y: 0, disk: nil),
+            Board.CellChange(x: 0, y: 1, disk: nil),
+            Board.CellChange(x: 1, y: 1, disk: .light),
+            Board.CellChange(x: 2, y: 1, disk: nil),
+            Board.CellChange(x: 3, y: 1, disk: .light),
+            Board.CellChange(x: 4, y: 1, disk: nil),
+            Board.CellChange(x: 5, y: 1, disk: nil),
+            Board.CellChange(x: 6, y: 1, disk: nil),
+            Board.CellChange(x: 7, y: 1, disk: nil),
+            Board.CellChange(x: 0, y: 2, disk: nil),
+            Board.CellChange(x: 1, y: 2, disk: nil),
+            Board.CellChange(x: 2, y: 2, disk: .light),
+            Board.CellChange(x: 3, y: 2, disk: .light),
+            Board.CellChange(x: 4, y: 2, disk: nil),
+            Board.CellChange(x: 5, y: 2, disk: .light),
+            Board.CellChange(x: 6, y: 2, disk: nil),
+            Board.CellChange(x: 7, y: 2, disk: nil),
+            Board.CellChange(x: 0, y: 3, disk: nil),
+            Board.CellChange(x: 1, y: 3, disk: nil),
+            Board.CellChange(x: 2, y: 3, disk: .dark),
+            Board.CellChange(x: 3, y: 3, disk: .light),
+            Board.CellChange(x: 4, y: 3, disk: .dark),
+            Board.CellChange(x: 5, y: 3, disk: .light),
+            Board.CellChange(x: 6, y: 3, disk: .dark),
+            Board.CellChange(x: 7, y: 3, disk: nil),
+            Board.CellChange(x: 0, y: 4, disk: nil),
+            Board.CellChange(x: 1, y: 4, disk: nil),
+            Board.CellChange(x: 2, y: 4, disk: nil),
+            Board.CellChange(x: 3, y: 4, disk: .dark),
+            Board.CellChange(x: 4, y: 4, disk: .light),
+            Board.CellChange(x: 5, y: 4, disk: .dark),
+            Board.CellChange(x: 6, y: 4, disk: nil),
+            Board.CellChange(x: 7, y: 4, disk: nil),
+            Board.CellChange(x: 0, y: 5, disk: nil),
+            Board.CellChange(x: 1, y: 5, disk: nil),
+            Board.CellChange(x: 2, y: 5, disk: nil),
+            Board.CellChange(x: 3, y: 5, disk: .light),
+            Board.CellChange(x: 4, y: 5, disk: .dark),
+            Board.CellChange(x: 5, y: 5, disk: .dark),
+            Board.CellChange(x: 6, y: 5, disk: .dark),
+            Board.CellChange(x: 7, y: 5, disk: nil),
+            Board.CellChange(x: 0, y: 6, disk: nil),
+            Board.CellChange(x: 1, y: 6, disk: nil),
+            Board.CellChange(x: 2, y: 6, disk: nil),
+            Board.CellChange(x: 3, y: 6, disk: .light),
+            Board.CellChange(x: 4, y: 6, disk: nil),
+            Board.CellChange(x: 5, y: 6, disk: .dark),
+            Board.CellChange(x: 6, y: 6, disk: nil),
+            Board.CellChange(x: 7, y: 6, disk: nil),
+            Board.CellChange(x: 0, y: 7, disk: nil),
+            Board.CellChange(x: 1, y: 7, disk: nil),
+            Board.CellChange(x: 2, y: 7, disk: .light),
+            Board.CellChange(x: 3, y: 7, disk: nil),
+            Board.CellChange(x: 4, y: 7, disk: nil),
+            Board.CellChange(x: 5, y: 7, disk: nil),
+            Board.CellChange(x: 6, y: 7, disk: nil),
+            Board.CellChange(x: 7, y: 7, disk: nil),
+        ])
+        
+        XCTAssertEqual(board.dumpAsText(), """
+            o-------
+            -o-o----
+            --oo-o--
+            --xoxox-
+            ---xox--
+            ---oxxx-
+            ---o-x--
+            --o-----
+            """
+        )
+    }
+    
+    func testRestoreFail() {
+        var board = Board()
+
+        let dump1: [[Disk?]] = [
+            [.light, nil, nil, nil, nil, nil, nil, nil],
+            [nil, .light, nil, .light, nil, nil, nil, nil],
+            [nil, nil, .light, .light, nil, .light, nil, nil],
+            [nil, nil, .dark, .light, .dark, .light, .dark, nil],
+        ]
+        XCTAssertThrowsError(try board.restore(from: dump1)) { error in
+            if case let BoardError.restore(dump: data) = error {
+                XCTAssertEqual(data, dump1)
+            } else {
+                XCTFail()
+            }
+        }
+        
+        let dump2: [[Disk?]] = [
+            [.light, nil, nil, nil, nil, nil, nil, nil],
+            [nil, .light, nil, .light, nil, nil, nil, nil],
+            [nil, nil, .light, .light, nil, .light, nil, nil, .light], // too many elements
+            [nil, nil, .dark, .light, .dark, .light, .dark, nil],
+            [nil, nil, nil, .dark, .light, .dark, nil, nil],
+            [nil, nil, nil, .light, .dark, .dark, .dark, nil],
+            [nil, nil, nil, .light, nil, .dark, nil, nil],
+            [nil, nil, .light, nil, nil, nil, nil, nil],
+        ]
+        XCTAssertThrowsError(try board.restore(from: dump2)) { error in
+            if case let BoardError.restore(dump: data) = error {
+                XCTAssertEqual(data, dump2)
+            } else {
+                XCTFail()
+            }
+        }
+    }
+    
     func testPlaceDisk() throws {
         var board = try Board(restoringFromText: """
             o-------
@@ -217,6 +348,30 @@ class BoardTests: XCTestCase {
             --o-----
             """
         )
+    }
+    
+    func testPlaceDiskFail() throws {
+        var board = try Board(restoringFromText: """
+            o-------
+            -o-o----
+            --oo-o--
+            --xoxox-
+            ---xox--
+            ---oxxx-
+            ---o-x--
+            --o-----
+            """
+        )
+
+        XCTAssertThrowsError(try board.placeDisk(.dark, atX: 2, y: 6)) { error in
+            if case let BoardError.diskPlacement(disk: errorDisk, x: errorX, y: errorY) = error {
+                XCTAssertEqual(errorDisk, .dark)
+                XCTAssertEqual(errorX, 2)
+                XCTAssertEqual(errorY, 6)
+            } else {
+                XCTFail()
+            }
+        }
     }
     
     func testCountDisks() throws {


### PR DESCRIPTION
## リバーシ盤のモデル `Board` を導入

`BoardView` がリバーシ盤のビューの役目とモデルの役目の両方を持っていましたが、モデルとしての部分だけを持つ `Board` 構造体を別に作りました。これに伴い、 `Board` プロトコルは廃止。旧 `Board` プロトコルの拡張として実装されていたメソッドは `Board` 構造体の一部になりました。

`Board` 構造体は `BoardView` とは異なり、リバーシ盤のルールに基づいた操作だけがメソッドとして公開されています。それ以外の、例えば任意のセルにディスクを置く `setDisk` のような操作は公開されていません。また、リバーシ盤の状態を変更するメソッドは、一連のセルの変更を戻り値として返します。

## `ViewController` の変更

`ViewController` では、新たに `Board` をメンバに持つようにし、ゲーム上のリバーシ盤の状態はこちらで管理するように変更しました。今後 `BoardView` については以下の機能のみを利用します。

- リバーシ盤の状態の表示 … `BoardView.setDisk(_:atX:y:animated:completion:)`
- ユーザーがセルをタップしたという入力の受け取り …　`BoardViewDelegate.boardView(_:didSelectCellAtX:y:)`

## 雑記

- Views、DataTypesの下にあるものは、将来、別ライブラリへ分離することを視野に入れているのか、 `internal` ではなくて、 `public` の修飾子が付けられています。 `Board` もこれに合わせて `public` にしました。
- `ViewController.placeDisk` のあたりが #1 でリファクタリングを行う前の状態に戻りつつありますが、 #1 の修正は今回のリファクタリングに向けての整理のために必要だったのです（言い訳） 💦 
- `Board` のテストケースも追加しました。
