### PR TITLE
Redux風のアーキテクチャでゲームを進行するモデルを作成

### DIFF
--- a/Reversi.xcodeproj/project.pbxproj
+++ b/Reversi.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		506C88C2245958C900A8946D /* UniqueIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88C1245958C900A8946D /* UniqueIdentifier.swift */; };
 		506C88C42459612A00A8946D /* ResetPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88C32459612A00A8946D /* ResetPhase.swift */; };
 		506C88C624596C5C00A8946D /* GameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88C524596C5C00A8946D /* GameTests.swift */; };
+		50C4F66D2459A56B00031283 /* ArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C4F66C2459A56B00031283 /* ArrayExtension.swift */; };
 		D636B39F23D35043007F370F /* DiskView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D636B39E23D35043007F370F /* DiskView.swift */; };
 		D642BDB423A9FE4500396732 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D642BDB323A9FE4500396732 /* AppDelegate.swift */; };
 		D642BDB623A9FE4500396732 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D642BDB523A9FE4500396732 /* SceneDelegate.swift */; };
@@ -67,6 +68,7 @@
 		506C88C1245958C900A8946D /* UniqueIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniqueIdentifier.swift; sourceTree = "<group>"; };
 		506C88C32459612A00A8946D /* ResetPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPhase.swift; sourceTree = "<group>"; };
 		506C88C524596C5C00A8946D /* GameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameTests.swift; sourceTree = "<group>"; };
+		50C4F66C2459A56B00031283 /* ArrayExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtension.swift; sourceTree = "<group>"; };
 		D636B39E23D35043007F370F /* DiskView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskView.swift; sourceTree = "<group>"; };
 		D642BDB023A9FE4500396732 /* Reversi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Reversi.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D642BDB323A9FE4500396732 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -147,6 +149,7 @@
 				D642BDD723AA0B5700396732 /* Disk.swift */,
 				50182BFD2458518B00BDC2B6 /* PlayerMode.swift */,
 				506C88C1245958C900A8946D /* UniqueIdentifier.swift */,
+				50C4F66C2459A56B00031283 /* ArrayExtension.swift */,
 			);
 			name = DataTypes;
 			sourceTree = "<group>";
@@ -301,6 +304,7 @@
 				D636B39F23D35043007F370F /* DiskView.swift in Sources */,
 				506C88AD2458783700A8946D /* Action.swift in Sources */,
 				50182BFC24584C4500BDC2B6 /* Game.swift in Sources */,
+				50C4F66D2459A56B00031283 /* ArrayExtension.swift in Sources */,
 				506C88BA24594C4100A8946D /* PlacingDiskPhase.swift in Sources */,
 				D642BDD623AA0B3900396732 /* CellView.swift in Sources */,
 				506C88A9245872E300A8946D /* State.swift in Sources */,

--- a/Reversi.xcodeproj/project.pbxproj
+++ b/Reversi.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		506C88C42459612A00A8946D /* ResetPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88C32459612A00A8946D /* ResetPhase.swift */; };
 		506C88C624596C5C00A8946D /* GameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88C524596C5C00A8946D /* GameTests.swift */; };
 		50C4F66D2459A56B00031283 /* ArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C4F66C2459A56B00031283 /* ArrayExtension.swift */; };
+		50C4F66F2459AA4700031283 /* EventuallyFulfill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C4F66E2459AA4700031283 /* EventuallyFulfill.swift */; };
 		D636B39F23D35043007F370F /* DiskView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D636B39E23D35043007F370F /* DiskView.swift */; };
 		D642BDB423A9FE4500396732 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D642BDB323A9FE4500396732 /* AppDelegate.swift */; };
 		D642BDB623A9FE4500396732 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D642BDB523A9FE4500396732 /* SceneDelegate.swift */; };
@@ -69,6 +70,7 @@
 		506C88C32459612A00A8946D /* ResetPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPhase.swift; sourceTree = "<group>"; };
 		506C88C524596C5C00A8946D /* GameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameTests.swift; sourceTree = "<group>"; };
 		50C4F66C2459A56B00031283 /* ArrayExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtension.swift; sourceTree = "<group>"; };
+		50C4F66E2459AA4700031283 /* EventuallyFulfill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventuallyFulfill.swift; sourceTree = "<group>"; };
 		D636B39E23D35043007F370F /* DiskView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskView.swift; sourceTree = "<group>"; };
 		D642BDB023A9FE4500396732 /* Reversi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Reversi.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D642BDB323A9FE4500396732 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -130,6 +132,14 @@
 				506C88C32459612A00A8946D /* ResetPhase.swift */,
 			);
 			name = Phases;
+			sourceTree = "<group>";
+		};
+		50C4F6712459AD6300031283 /* Utility */ = {
+			isa = PBXGroup;
+			children = (
+				50C4F66E2459AA4700031283 /* EventuallyFulfill.swift */,
+			);
+			name = Utility;
 			sourceTree = "<group>";
 		};
 		D636B3A123D43203007F370F /* Views */ = {
@@ -195,6 +205,7 @@
 				D642BDCA23A9FE4700396732 /* ReversiTests.swift */,
 				50182BF92455C68600BDC2B6 /* BoardTests.swift */,
 				506C88C524596C5C00A8946D /* GameTests.swift */,
+				50C4F6712459AD6300031283 /* Utility */,
 				D642BDCC23A9FE4700396732 /* Info.plist */,
 			);
 			path = ReversiTests;
@@ -333,6 +344,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				50182BFA2455C68600BDC2B6 /* BoardTests.swift in Sources */,
+				50C4F66F2459AA4700031283 /* EventuallyFulfill.swift in Sources */,
 				506C88C624596C5C00A8946D /* GameTests.swift in Sources */,
 				D642BDCB23A9FE4700396732 /* ReversiTests.swift in Sources */,
 			);

--- a/Reversi.xcodeproj/project.pbxproj
+++ b/Reversi.xcodeproj/project.pbxproj
@@ -15,6 +15,16 @@
 		506C88AD2458783700A8946D /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88AC2458783700A8946D /* Action.swift */; };
 		506C88AF245879E000A8946D /* InitialPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88AE245879E000A8946D /* InitialPhase.swift */; };
 		506C88B22459310F00A8946D /* Phase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88B12459310F00A8946D /* Phase.swift */; };
+		506C88B424593DC000A8946D /* WaitForPlayerPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88B324593DC000A8946D /* WaitForPlayerPhase.swift */; };
+		506C88B624594B0F00A8946D /* ThinkingPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88B524594B0F00A8946D /* ThinkingPhase.swift */; };
+		506C88B824594BF800A8946D /* PlaceDiskPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88B724594BF800A8946D /* PlaceDiskPhase.swift */; };
+		506C88BA24594C4100A8946D /* PlacingDiskPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88B924594C4100A8946D /* PlacingDiskPhase.swift */; };
+		506C88BC24594C7D00A8946D /* NextTurnPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88BB24594C7D00A8946D /* NextTurnPhase.swift */; };
+		506C88BE24594D3F00A8946D /* PassPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88BD24594D3F00A8946D /* PassPhase.swift */; };
+		506C88C024594D7200A8946D /* GameOverPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88BF24594D7200A8946D /* GameOverPhase.swift */; };
+		506C88C2245958C900A8946D /* UniqueIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88C1245958C900A8946D /* UniqueIdentifier.swift */; };
+		506C88C42459612A00A8946D /* ResetPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88C32459612A00A8946D /* ResetPhase.swift */; };
+		506C88C624596C5C00A8946D /* GameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88C524596C5C00A8946D /* GameTests.swift */; };
 		D636B39F23D35043007F370F /* DiskView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D636B39E23D35043007F370F /* DiskView.swift */; };
 		D642BDB423A9FE4500396732 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D642BDB323A9FE4500396732 /* AppDelegate.swift */; };
 		D642BDB623A9FE4500396732 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D642BDB523A9FE4500396732 /* SceneDelegate.swift */; };
@@ -47,6 +57,16 @@
 		506C88AC2458783700A8946D /* Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
 		506C88AE245879E000A8946D /* InitialPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialPhase.swift; sourceTree = "<group>"; };
 		506C88B12459310F00A8946D /* Phase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Phase.swift; sourceTree = "<group>"; };
+		506C88B324593DC000A8946D /* WaitForPlayerPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitForPlayerPhase.swift; sourceTree = "<group>"; };
+		506C88B524594B0F00A8946D /* ThinkingPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThinkingPhase.swift; sourceTree = "<group>"; };
+		506C88B724594BF800A8946D /* PlaceDiskPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceDiskPhase.swift; sourceTree = "<group>"; };
+		506C88B924594C4100A8946D /* PlacingDiskPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlacingDiskPhase.swift; sourceTree = "<group>"; };
+		506C88BB24594C7D00A8946D /* NextTurnPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextTurnPhase.swift; sourceTree = "<group>"; };
+		506C88BD24594D3F00A8946D /* PassPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassPhase.swift; sourceTree = "<group>"; };
+		506C88BF24594D7200A8946D /* GameOverPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameOverPhase.swift; sourceTree = "<group>"; };
+		506C88C1245958C900A8946D /* UniqueIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniqueIdentifier.swift; sourceTree = "<group>"; };
+		506C88C32459612A00A8946D /* ResetPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPhase.swift; sourceTree = "<group>"; };
+		506C88C524596C5C00A8946D /* GameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameTests.swift; sourceTree = "<group>"; };
 		D636B39E23D35043007F370F /* DiskView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskView.swift; sourceTree = "<group>"; };
 		D642BDB023A9FE4500396732 /* Reversi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Reversi.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D642BDB323A9FE4500396732 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -98,6 +118,14 @@
 			isa = PBXGroup;
 			children = (
 				506C88AE245879E000A8946D /* InitialPhase.swift */,
+				506C88B324593DC000A8946D /* WaitForPlayerPhase.swift */,
+				506C88B524594B0F00A8946D /* ThinkingPhase.swift */,
+				506C88B724594BF800A8946D /* PlaceDiskPhase.swift */,
+				506C88B924594C4100A8946D /* PlacingDiskPhase.swift */,
+				506C88BB24594C7D00A8946D /* NextTurnPhase.swift */,
+				506C88BD24594D3F00A8946D /* PassPhase.swift */,
+				506C88BF24594D7200A8946D /* GameOverPhase.swift */,
+				506C88C32459612A00A8946D /* ResetPhase.swift */,
 			);
 			name = Phases;
 			sourceTree = "<group>";
@@ -118,6 +146,7 @@
 				503FF3F92453123900D944A8 /* Board.swift */,
 				D642BDD723AA0B5700396732 /* Disk.swift */,
 				50182BFD2458518B00BDC2B6 /* PlayerMode.swift */,
+				506C88C1245958C900A8946D /* UniqueIdentifier.swift */,
 			);
 			name = DataTypes;
 			sourceTree = "<group>";
@@ -162,6 +191,7 @@
 			children = (
 				D642BDCA23A9FE4700396732 /* ReversiTests.swift */,
 				50182BF92455C68600BDC2B6 /* BoardTests.swift */,
+				506C88C524596C5C00A8946D /* GameTests.swift */,
 				D642BDCC23A9FE4700396732 /* Info.plist */,
 			);
 			path = ReversiTests;
@@ -271,17 +301,26 @@
 				D636B39F23D35043007F370F /* DiskView.swift in Sources */,
 				506C88AD2458783700A8946D /* Action.swift in Sources */,
 				50182BFC24584C4500BDC2B6 /* Game.swift in Sources */,
+				506C88BA24594C4100A8946D /* PlacingDiskPhase.swift in Sources */,
 				D642BDD623AA0B3900396732 /* CellView.swift in Sources */,
 				506C88A9245872E300A8946D /* State.swift in Sources */,
+				506C88BE24594D3F00A8946D /* PassPhase.swift in Sources */,
 				506C88AF245879E000A8946D /* InitialPhase.swift in Sources */,
 				D642BDD823AA0B5700396732 /* Disk.swift in Sources */,
 				D642BDB823A9FE4500396732 /* ViewController.swift in Sources */,
 				50182BFE2458518B00BDC2B6 /* PlayerMode.swift in Sources */,
+				506C88B424593DC000A8946D /* WaitForPlayerPhase.swift in Sources */,
 				506C88B22459310F00A8946D /* Phase.swift in Sources */,
+				506C88C42459612A00A8946D /* ResetPhase.swift in Sources */,
+				506C88BC24594C7D00A8946D /* NextTurnPhase.swift in Sources */,
+				506C88C024594D7200A8946D /* GameOverPhase.swift in Sources */,
+				506C88B624594B0F00A8946D /* ThinkingPhase.swift in Sources */,
 				D642BDDC23AA137C00396732 /* BoardView.swift in Sources */,
+				506C88C2245958C900A8946D /* UniqueIdentifier.swift in Sources */,
 				D642BDB423A9FE4500396732 /* AppDelegate.swift in Sources */,
 				503FF3FA2453123900D944A8 /* Board.swift in Sources */,
 				D642BDB623A9FE4500396732 /* SceneDelegate.swift in Sources */,
+				506C88B824594BF800A8946D /* PlaceDiskPhase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -290,6 +329,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				50182BFA2455C68600BDC2B6 /* BoardTests.swift in Sources */,
+				506C88C624596C5C00A8946D /* GameTests.swift in Sources */,
 				D642BDCB23A9FE4700396732 /* ReversiTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Reversi.xcodeproj/project.pbxproj
+++ b/Reversi.xcodeproj/project.pbxproj
@@ -8,7 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		50182BFA2455C68600BDC2B6 /* BoardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50182BF92455C68600BDC2B6 /* BoardTests.swift */; };
+		50182BFC24584C4500BDC2B6 /* Game.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50182BFB24584C4500BDC2B6 /* Game.swift */; };
+		50182BFE2458518B00BDC2B6 /* PlayerMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50182BFD2458518B00BDC2B6 /* PlayerMode.swift */; };
 		503FF3FA2453123900D944A8 /* Board.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503FF3F92453123900D944A8 /* Board.swift */; };
+		506C88A9245872E300A8946D /* State.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88A8245872E300A8946D /* State.swift */; };
+		506C88AD2458783700A8946D /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88AC2458783700A8946D /* Action.swift */; };
+		506C88AF245879E000A8946D /* InitialPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88AE245879E000A8946D /* InitialPhase.swift */; };
+		506C88B22459310F00A8946D /* Phase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88B12459310F00A8946D /* Phase.swift */; };
 		D636B39F23D35043007F370F /* DiskView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D636B39E23D35043007F370F /* DiskView.swift */; };
 		D642BDB423A9FE4500396732 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D642BDB323A9FE4500396732 /* AppDelegate.swift */; };
 		D642BDB623A9FE4500396732 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D642BDB523A9FE4500396732 /* SceneDelegate.swift */; };
@@ -34,7 +40,13 @@
 
 /* Begin PBXFileReference section */
 		50182BF92455C68600BDC2B6 /* BoardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardTests.swift; sourceTree = "<group>"; };
+		50182BFB24584C4500BDC2B6 /* Game.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Game.swift; sourceTree = "<group>"; };
+		50182BFD2458518B00BDC2B6 /* PlayerMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerMode.swift; sourceTree = "<group>"; };
 		503FF3F92453123900D944A8 /* Board.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Board.swift; sourceTree = "<group>"; };
+		506C88A8245872E300A8946D /* State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = State.swift; sourceTree = "<group>"; };
+		506C88AC2458783700A8946D /* Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
+		506C88AE245879E000A8946D /* InitialPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialPhase.swift; sourceTree = "<group>"; };
+		506C88B12459310F00A8946D /* Phase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Phase.swift; sourceTree = "<group>"; };
 		D636B39E23D35043007F370F /* DiskView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskView.swift; sourceTree = "<group>"; };
 		D642BDB023A9FE4500396732 /* Reversi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Reversi.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D642BDB323A9FE4500396732 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -70,6 +82,26 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		506C88A72458725B00A8946D /* GameEngine */ = {
+			isa = PBXGroup;
+			children = (
+				50182BFB24584C4500BDC2B6 /* Game.swift */,
+				506C88A8245872E300A8946D /* State.swift */,
+				506C88AC2458783700A8946D /* Action.swift */,
+				506C88B12459310F00A8946D /* Phase.swift */,
+				506C88B0245879EB00A8946D /* Phases */,
+			);
+			name = GameEngine;
+			sourceTree = "<group>";
+		};
+		506C88B0245879EB00A8946D /* Phases */ = {
+			isa = PBXGroup;
+			children = (
+				506C88AE245879E000A8946D /* InitialPhase.swift */,
+			);
+			name = Phases;
+			sourceTree = "<group>";
+		};
 		D636B3A123D43203007F370F /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -85,6 +117,7 @@
 			children = (
 				503FF3F92453123900D944A8 /* Board.swift */,
 				D642BDD723AA0B5700396732 /* Disk.swift */,
+				50182BFD2458518B00BDC2B6 /* PlayerMode.swift */,
 			);
 			name = DataTypes;
 			sourceTree = "<group>";
@@ -117,6 +150,7 @@
 				D642BDBC23A9FE4700396732 /* Assets.xcassets */,
 				D642BDBE23A9FE4700396732 /* LaunchScreen.storyboard */,
 				D642BDC123A9FE4700396732 /* Info.plist */,
+				506C88A72458725B00A8946D /* GameEngine */,
 				D636B3A123D43203007F370F /* Views */,
 				D636B3A423D432D3007F370F /* DataTypes */,
 			);
@@ -235,9 +269,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				D636B39F23D35043007F370F /* DiskView.swift in Sources */,
+				506C88AD2458783700A8946D /* Action.swift in Sources */,
+				50182BFC24584C4500BDC2B6 /* Game.swift in Sources */,
 				D642BDD623AA0B3900396732 /* CellView.swift in Sources */,
+				506C88A9245872E300A8946D /* State.swift in Sources */,
+				506C88AF245879E000A8946D /* InitialPhase.swift in Sources */,
 				D642BDD823AA0B5700396732 /* Disk.swift in Sources */,
 				D642BDB823A9FE4500396732 /* ViewController.swift in Sources */,
+				50182BFE2458518B00BDC2B6 /* PlayerMode.swift in Sources */,
+				506C88B22459310F00A8946D /* Phase.swift in Sources */,
 				D642BDDC23AA137C00396732 /* BoardView.swift in Sources */,
 				D642BDB423A9FE4500396732 /* AppDelegate.swift in Sources */,
 				503FF3FA2453123900D944A8 /* Board.swift in Sources */,

--- a/Reversi.xcodeproj/project.pbxproj
+++ b/Reversi.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		506C88C624596C5C00A8946D /* GameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C88C524596C5C00A8946D /* GameTests.swift */; };
 		50C4F66D2459A56B00031283 /* ArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C4F66C2459A56B00031283 /* ArrayExtension.swift */; };
 		50C4F66F2459AA4700031283 /* EventuallyFulfill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C4F66E2459AA4700031283 /* EventuallyFulfill.swift */; };
+		50CE311D245D4C5300D2EF2A /* Engine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50CE311C245D4C5300D2EF2A /* Engine.swift */; };
+		50CE311F245D4CD400D2EF2A /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50CE311E245D4CD400D2EF2A /* Logger.swift */; };
 		D636B39F23D35043007F370F /* DiskView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D636B39E23D35043007F370F /* DiskView.swift */; };
 		D642BDB423A9FE4500396732 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D642BDB323A9FE4500396732 /* AppDelegate.swift */; };
 		D642BDB623A9FE4500396732 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D642BDB523A9FE4500396732 /* SceneDelegate.swift */; };
@@ -71,6 +73,8 @@
 		506C88C524596C5C00A8946D /* GameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameTests.swift; sourceTree = "<group>"; };
 		50C4F66C2459A56B00031283 /* ArrayExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtension.swift; sourceTree = "<group>"; };
 		50C4F66E2459AA4700031283 /* EventuallyFulfill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventuallyFulfill.swift; sourceTree = "<group>"; };
+		50CE311C245D4C5300D2EF2A /* Engine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Engine.swift; sourceTree = "<group>"; };
+		50CE311E245D4CD400D2EF2A /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		D636B39E23D35043007F370F /* DiskView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskView.swift; sourceTree = "<group>"; };
 		D642BDB023A9FE4500396732 /* Reversi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Reversi.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D642BDB323A9FE4500396732 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -110,6 +114,8 @@
 			isa = PBXGroup;
 			children = (
 				50182BFB24584C4500BDC2B6 /* Game.swift */,
+				50CE311C245D4C5300D2EF2A /* Engine.swift */,
+				50CE311E245D4CD400D2EF2A /* Logger.swift */,
 				506C88A8245872E300A8946D /* State.swift */,
 				506C88AC2458783700A8946D /* Action.swift */,
 				506C88B12459310F00A8946D /* Phase.swift */,
@@ -321,6 +327,7 @@
 				506C88A9245872E300A8946D /* State.swift in Sources */,
 				506C88BE24594D3F00A8946D /* PassPhase.swift in Sources */,
 				506C88AF245879E000A8946D /* InitialPhase.swift in Sources */,
+				50CE311F245D4CD400D2EF2A /* Logger.swift in Sources */,
 				D642BDD823AA0B5700396732 /* Disk.swift in Sources */,
 				D642BDB823A9FE4500396732 /* ViewController.swift in Sources */,
 				50182BFE2458518B00BDC2B6 /* PlayerMode.swift in Sources */,
@@ -336,6 +343,7 @@
 				503FF3FA2453123900D944A8 /* Board.swift in Sources */,
 				D642BDB623A9FE4500396732 /* SceneDelegate.swift in Sources */,
 				506C88B824594BF800A8946D /* PlaceDiskPhase.swift in Sources */,
+				50CE311D245D4C5300D2EF2A /* Engine.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Reversi/Action.swift
+++ b/Reversi/Action.swift
@@ -1,15 +1,61 @@
 import Foundation
 
-public enum ActionCreators {
-    static func changePhase<P: Phase>(to phase: P) -> Thunk {
+/// アクションっぽいもの
+public enum Actionish {
+    /// 実際のアクションです。
+    case action(Action)
+    
+    /// アクションを遅延ディスパッチするサンクです。
+    case thunk(Thunk)
+}
+
+extension Actionish {
+    /// ゲームを開始するときにこのメソッドの結果をディスパッチします。
+    public static func start() -> Actionish {
+        return .action(.start)
+    }
+    
+    /// ボードのセルが選択されたときに、このメソッドの結果をディスパッチします。
+    public static func boardCellSelected(x: Int, y: Int) -> Actionish {
+        return .action(.boardCellSelected(x: x, y: y))
+    }
+    
+    /// 黒・白のプレイヤーモードが変更されたときに、このメソッドの結果をディスパッチします。
+    public static func playerModeChanged(player: Disk, mode: PlayerMode) -> Actionish {
+        return .action(.playerModeChanged(player: player, mode: mode))
+    }
+    
+    /// リセットボタンが押されたときに、このメソッドの結果をディスパッチします。
+    public static func reset() -> Actionish {
+        return .action(.reset)
+    }
+    
+    /// リセットの確認ができたときに、このメソッドの結果をディスパッチします。
+    public static func resetConfirmed(requestId: UniqueIdentifier, execute: Bool) -> Actionish {
+        return .action(.resetConfirmed(requestId: requestId, execute: execute))
+    }
+    
+    /// 「パス」の表示が消されたときに、このメソッドの結果をディスパッチします。
+    public static func passDismissed(requestId: UniqueIdentifier) -> Actionish {
+        return .action(.passDismissed(requestId: requestId))
+    }
+    
+    /// リバーシ盤の更新が完了したときに、このメソッドの結果をディスパッチします。
+    public static func boardUpdated(requestId: UniqueIdentifier) -> Actionish {
+        return .action(.boardUpdated(requestId: requestId))
+    }
+}
+
+extension Actionish {
+    static func changePhase<P: Phase>(to phase: P) -> Actionish {
         return changePhase(to: AnyPhase(phase))
     }
     
     /// フェーズを変更するサンクを生成します。
     /// - Parameter phase: 次のフェーズ
     /// - Returns: 生成したサンクを返します。
-    static func changePhase(to phase: AnyPhase) -> Thunk {
-        return { (dispatcher, state) in
+    static func changePhase(to phase: AnyPhase) -> Actionish {
+        return .thunk({ (dispatcher, state) in
             // onExitやonEnterの中でchangePhaseがディスパッチされても大丈夫なように
             // changePhaseは必ず次のタイミングで行う
             DispatchQueue.main.async {
@@ -17,11 +63,11 @@ public enum ActionCreators {
                 
                 // 前のフェーズのonExitを呼び出す
                 if let thunk = state.phase.onExit(nextPhase: phase) {
-                    dispatcher.dispatch(thunk)
+                    dispatcher.dispatch(thunk: thunk)
                 }
                 
                 // フェーズを変更する
-                dispatcher.dispatch(ActionCreators.setState { state in
+                dispatcher.dispatch(.setState { state in
                     var state = state
                     state.phase = phase
                     return state
@@ -29,23 +75,23 @@ public enum ActionCreators {
                 
                 // 次のフェーズのonEnterを呼び出す
                 if let thunk = phase.onEnter(previousPhase: prevPhase) {
-                    dispatcher.dispatch(thunk)
+                    dispatcher.dispatch(thunk: thunk)
                 }
             }
-        }
+        })
     }
     
     /// Reducer相当のクロージャーを指定して任意に状態を変更できるアクションを生成します。
     /// - Parameter closure: 状態を変更する方法
     /// - Returns: 生成したアクションを返します。
-    static func setState(closure: @escaping (State) -> State) -> Action {
+    static func setState(closure: @escaping (State) -> State) -> Actionish {
         struct ClosureReducer: Reducer {
             let closure: (State) -> State
             func reduce(state: State, action: Action) -> State {
                 return closure(state)
             }
         }
-        return ._setState(reducer: ClosureReducer(closure: closure))
+        return .action(._setState(reducer: ClosureReducer(closure: closure)))
     }
 }
 

--- a/Reversi/Action.swift
+++ b/Reversi/Action.swift
@@ -65,15 +65,15 @@ extension Actionish {
                 
                 // 前のフェーズのonExitを呼び出す
                 if let thunk = state.phase.onExit(nextPhase: phase) {
-                    dispatcher.dispatch(thunk: thunk)
+                    dispatcher.dispatch(.thunk(thunk))
                 }
                 
                 // フェーズを変更する
-                dispatcher.dispatch(action: .changePhase(nextPhase: phase))
+                dispatcher.dispatch(.action(.changePhase(nextPhase: phase)))
                 
                 // 次のフェーズのonEnterを呼び出す
                 if let thunk = phase.onEnter(previousPhase: prevPhase) {
-                    dispatcher.dispatch(thunk: thunk)
+                    dispatcher.dispatch(.thunk(thunk))
                 }
             }
         })

--- a/Reversi/Action.swift
+++ b/Reversi/Action.swift
@@ -15,13 +15,10 @@ public enum Action {
     case reset
     
     /// リセットの確認ができたときにディスパッチするアクションです。
-    case executeReset
-    
-    /// 「パス」の表示を行ったときにディスパッチするアクションです。
-    case passNotified(requestId: UniqueIdentifier)
+    case resetConfirmed(requestId: UniqueIdentifier, execute: Bool)
     
     /// 「パス」の表示が消されたときにディスパッチするアクションです。
-    case passDismissed
+    case passDismissed(requestId: UniqueIdentifier)
     
     /// リバーシ盤の更新が完了したときにディスパッチするアクションです。
     case boardUpdated(requestId: UniqueIdentifier)

--- a/Reversi/Action.swift
+++ b/Reversi/Action.swift
@@ -1,5 +1,54 @@
 import Foundation
 
+public enum ActionCreators {
+    static func changePhase<P: Phase>(to phase: P) -> Thunk {
+        return changePhase(to: AnyPhase(phase))
+    }
+    
+    /// フェーズを変更するサンクを生成します。
+    /// - Parameter phase: 次のフェーズ
+    /// - Returns: 生成したサンクを返します。
+    static func changePhase(to phase: AnyPhase) -> Thunk {
+        return { (dispatcher, state) in
+            // onExitやonEnterの中でchangePhaseがディスパッチされても大丈夫なように
+            // changePhaseは必ず次のタイミングで行う
+            DispatchQueue.main.async {
+                let prevPhase = state.phase
+                
+                // 前のフェーズのonExitを呼び出す
+                if let thunk = state.phase.onExit(nextPhase: phase) {
+                    dispatcher.dispatch(thunk)
+                }
+                
+                // フェーズを変更する
+                dispatcher.dispatch(ActionCreators.setState { state in
+                    var state = state
+                    state.phase = phase
+                    return state
+                })
+                
+                // 次のフェーズのonEnterを呼び出す
+                if let thunk = phase.onEnter(previousPhase: prevPhase) {
+                    dispatcher.dispatch(thunk)
+                }
+            }
+        }
+    }
+    
+    /// Reducer相当のクロージャーを指定して任意に状態を変更できるアクションを生成します。
+    /// - Parameter closure: 状態を変更する方法
+    /// - Returns: 生成したアクションを返します。
+    static func setState(closure: @escaping (State) -> State) -> Action {
+        struct ClosureReducer: Reducer {
+            let closure: (State) -> State
+            func reduce(state: State, action: Action) -> State {
+                return closure(state)
+            }
+        }
+        return ._setState(reducer: ClosureReducer(closure: closure))
+    }
+}
+
 /// ゲームの状態を進めるためのアクションです。
 public enum Action {
     /// ゲームを開始するときにディスパッチするアクションです。
@@ -22,4 +71,8 @@ public enum Action {
     
     /// リバーシ盤の更新が完了したときにディスパッチするアクションです。
     case boardUpdated(requestId: UniqueIdentifier)
+
+    /// （内部利用）状態変更の方法を指示したアクションです。
+    case _setState(reducer: Reducer)
 }
+

--- a/Reversi/Action.swift
+++ b/Reversi/Action.swift
@@ -9,7 +9,7 @@ public enum Action {
     case boardCellSelected(x: Int, y: Int)
     
     /// 黒・白のプレイヤーモードが変更されたときにディスパッチするアクションです。
-    case playerModeChanged(player: Disk?, mode: PlayerMode)
+    case playerModeChanged(player: Disk, mode: PlayerMode)
     
     /// リセットボタンが押されたときにディスパッチするアクションです。
     case reset
@@ -17,9 +17,12 @@ public enum Action {
     /// リセットの確認ができたときにディスパッチするアクションです。
     case executeReset
     
-    /// 「パス」の表示を消したときにディスパッチするアクションです。
-    case dismissPass
+    /// 「パス」の表示を行ったときにディスパッチするアクションです。
+    case passNotified(requestId: UniqueIdentifier)
     
-    /// ディスクをセットするアニメーションが終わったらディスパッチするアクションです。
-    case diskAnimationCompleted
+    /// 「パス」の表示が消されたときにディスパッチするアクションです。
+    case passDismissed
+    
+    /// リバーシ盤の更新が完了したときにディスパッチするアクションです。
+    case boardUpdated(requestId: UniqueIdentifier)
 }

--- a/Reversi/Action.swift
+++ b/Reversi/Action.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// ゲームの状態を進めるためのアクションです。
+public enum Action {
+    /// ゲームを開始するときにディスパッチするアクションです。
+    case start
+    
+    /// ボードのセルが選択されたときにディスパッチするアクションです。
+    case boardCellSelected(x: Int, y: Int)
+    
+    /// 黒・白のプレイヤーモードが変更されたときにディスパッチするアクションです。
+    case playerModeChanged(player: Disk?, mode: PlayerMode)
+    
+    /// リセットボタンが押されたときにディスパッチするアクションです。
+    case reset
+    
+    /// リセットの確認ができたときにディスパッチするアクションです。
+    case executeReset
+    
+    /// 「パス」の表示を消したときにディスパッチするアクションです。
+    case dismissPass
+    
+    /// ディスクをセットするアニメーションが終わったらディスパッチするアクションです。
+    case diskAnimationCompleted
+}

--- a/Reversi/ArrayExtension.swift
+++ b/Reversi/ArrayExtension.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension Array {
+    public subscript(_ disk: Disk) -> Element {
+        get {
+            return self[disk.index]
+        }
+        set {
+            self[disk.index] = newValue
+        }
+    }
+}
+
+extension Disk {
+    fileprivate var index: Int {
+        switch self {
+        case .dark: return 0
+        case .light: return 1
+        }
+    }
+}

--- a/Reversi/Engine.swift
+++ b/Reversi/Engine.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Combine
+
+/// アクションに応じて状態を変更する `reduce` メソッドを持ちます。
+/// `reduce` メソッドでは、変更したStateを返す以外の方法で
+/// 状態を変更してはいけません。また、非同期処理の呼び出しなど
+/// 副作用のあることを行ってはいけません。
+public protocol Reducer {
+    /// アクションに応じて状態を変更します。
+    /// - Parameters:
+    ///   - state: 変更前の状態です。
+    ///   - action: 状態変更を要求するアクションです。
+    /// - Returns: 変更後の状態を返します。
+    static func reduce(state: State, action: Action) -> State
+}
+
+/// アクションをディスパッチするメソッドを持ちます。
+public protocol Dispatcher {
+    /// アクションらしきものをディスパッチします。
+    /// - Parameter actionish: アクションらしきもの
+    func dispatch(_ actionish: Actionish)
+}
+
+/// アクションのディスパッチを遅延実行させるための関数です。
+/// サンクの中では非同期処理の呼び出しなど副作用のある
+/// 動作を行っても構いません。
+public typealias Thunk = (Dispatcher, State) -> Void
+
+/// ディスパッチ処理を必要に応じて拡張するためのものです。
+public protocol Middleware {
+    static func extend(game: Game, next: Dispatcher) -> Dispatcher
+}
+
+public class Store: Dispatcher {
+    /// 状態を保持するものです。
+    public let stateHolder: CurrentValueSubject<State, Never>
+    
+    /// 状態を変更するものです。
+    private let reducer: Reducer.Type
+
+    public init(initialState: State, reducer: Reducer.Type) {
+        stateHolder = CurrentValueSubject(initialState)
+        self.reducer = reducer
+    }
+
+    /// アクションらしきものをディスパッチします。
+    /// - Parameter actionish: アクションらしきもの
+    public func dispatch(_ actionish: Actionish) {
+        switch actionish {
+        case .action(let action):
+            dispatch(action: action)
+            
+        case .thunk(let thunk):
+            dispatch(thunk: thunk)
+        }
+    }
+
+    /// アクションをディスパッチします。
+    /// - Parameter action: ディスパッチ対象のアクション
+    public func dispatch(action: Action) {
+        var state = stateHolder.value
+        state = reducer.reduce(state: state, action: action)
+
+        // ループ用サンクは取り出しておく
+        let thunks = state._loops
+        state._loops = []
+        
+        stateHolder.value = state
+        
+        for thunk in thunks {
+            dispatch(thunk: thunk)
+        }
+    }
+
+    /// サンクを用いてアクションをディスパッチします。
+    /// - Parameter thunk: サンク
+    public func dispatch(thunk: Thunk) {
+        thunk(self, stateHolder.value)
+    }
+}

--- a/Reversi/Engine.swift
+++ b/Reversi/Engine.swift
@@ -31,6 +31,9 @@ public protocol Middleware {
     static func extend(game: Game, next: Dispatcher) -> Dispatcher
 }
 
+/// 実際に状態を保持し、ディスパッチャーとなる基本のストア実装です。
+/// `Game` はこれを内部的に持ちますが、 `Game` のディスパッチャーは
+/// ミドルウェアを挟んだものになっていて、 `Store` そのものではありません。
 public class Store: Dispatcher {
     /// 状態を保持するものです。
     public let stateHolder: CurrentValueSubject<State, Never>

--- a/Reversi/Game.swift
+++ b/Reversi/Game.swift
@@ -1,36 +1,6 @@
 import Foundation
 import Combine
 
-/// アクションに応じて状態を変更する `reduce` メソッドを持ちます。
-/// `reduce` メソッドでは、変更したStateを返す以外の方法で
-/// 状態を変更してはいけません。また、非同期処理の呼び出しなど
-/// 副作用のあることを行ってはいけません。
-public protocol Reducer {
-    /// アクションに応じて状態を変更します。
-    /// - Parameters:
-    ///   - state: 変更前の状態です。
-    ///   - action: 状態変更を要求するアクションです。
-    /// - Returns: 変更後の状態を返します。
-    static func reduce(state: State, action: Action) -> State
-}
-
-/// アクションをディスパッチするメソッドを持ちます。
-public protocol Dispatcher {
-    /// アクションらしきものをディスパッチします。
-    /// - Parameter actionish: アクションらしきもの
-    func dispatch(_ actionish: Actionish)
-}
-
-/// アクションのディスパッチを遅延実行させるための関数です。
-/// サンクの中では非同期処理の呼び出しなど副作用のある
-/// 動作を行っても構いません。
-public typealias Thunk = (Dispatcher, State) -> Void
-
-/// ディスパッチ処理を必要に応じて拡張するためのものです。
-public protocol Middleware {
-    static func extend(game: Game, next: Dispatcher) -> Dispatcher
-}
-
 public enum GameError: Error {
     case restore(data: String)
 }
@@ -54,7 +24,7 @@ public class Game: Dispatcher {
     public init(state: State = State(board: Board(),
                                      turn: .dark,
                                      playerModes: [.manual, .manual]),
-                reducer: Reducer.Type = MainReducer.self,
+                reducer: Reducer.Type = GameReducer.self,
                 middlewares: [Middleware.Type] = []) {
         store = Store(initialState: state, reducer: reducer)
         statePublisher = store.stateHolder
@@ -79,76 +49,7 @@ public class Game: Dispatcher {
     }
 }
 
-public class Store: Dispatcher {
-    /// 状態を保持するものです。
-    public let stateHolder: CurrentValueSubject<State, Never>
-    
-    /// 状態を変更するものです。
-    private let reducer: Reducer.Type
-
-    public init(initialState: State, reducer: Reducer.Type) {
-        stateHolder = CurrentValueSubject(initialState)
-        self.reducer = reducer
-    }
-
-    /// アクションらしきものをディスパッチします。
-    /// - Parameter actionish: アクションらしきもの
-    public func dispatch(_ actionish: Actionish) {
-        switch actionish {
-        case .action(let action):
-            dispatch(action: action)
-            
-        case .thunk(let thunk):
-            dispatch(thunk: thunk)
-        }
-    }
-
-    /// アクションをディスパッチします。
-    /// - Parameter action: ディスパッチ対象のアクション
-    public func dispatch(action: Action) {
-        var state = stateHolder.value
-        state = reducer.reduce(state: state, action: action)
-
-        // ループ用サンクは取り出しておく
-        let thunks = state._loops
-        state._loops = []
-        
-        stateHolder.value = state
-        
-        for thunk in thunks {
-            dispatch(thunk: thunk)
-        }
-    }
-
-    /// サンクを用いてアクションをディスパッチします。
-    /// - Parameter thunk: サンク
-    public func dispatch(thunk: Thunk) {
-        thunk(self, stateHolder.value)
-    }
-}
-
-/// フェーズとアクションに関するログ出力を行うミドルウェアです。
-public class Logger: Middleware, Dispatcher {
-    private let game: Game
-    private let next: Dispatcher
-    
-    public init(game: Game, next: Dispatcher) {
-        self.game = game
-        self.next = next
-    }
-    
-    public static func extend(game: Game, next: Dispatcher) -> Dispatcher {
-        return Logger(game: game, next: next)
-    }
-
-    public func dispatch(_ actionish: Actionish) {
-        print("(Phase: \(game.state.phase),\n Action: \(actionish))")
-        next.dispatch(actionish)
-        print("  --> Phase: \(game.state.phase)")
-    }
-}
-
-public enum MainReducer: Reducer {
+public enum GameReducer: Reducer {
     public static func reduce(state: State, action: Action) -> State {
         var state = state
         let currentPhase = state.phase

--- a/Reversi/Game.swift
+++ b/Reversi/Game.swift
@@ -35,8 +35,7 @@ public class Game {
     public convenience init() {
         let state = State(board: Board(),
                           turn: .dark,
-                          playerModes: [.manual, .manual],
-                          phase: AnyPhase(InitialPhase()))
+                          playerModes: [.manual, .manual])
         self.init(state: state, reducer: MainReducer())
     }
 

--- a/Reversi/Game.swift
+++ b/Reversi/Game.swift
@@ -2,7 +2,7 @@ import Foundation
 import Combine
 
 /// アクションに応じて状態を変更する `reduce` メソッドを持ちます。
-/// このプロトコルは基本的に値型で準拠することを想定しています。
+/// このプロトコルは値型で準拠することを想定しています。
 /// `reduce` メソッドでは、自身の型で保持する値であっても、
 /// 変更したStateを返す以外の方法で状態を変更してはいけません。
 /// また、このメソッド内では非同期処理の呼び出しなど
@@ -104,9 +104,9 @@ public class Game: Dispatcher {
         var state = stateHolder.value
         state = reducer.reduce(state: state, action: action)
 
-        // サンクは取り出しておく
-        let thunks = state.thunks
-        state.thunks = []
+        // ループ用サンクは取り出しておく
+        let thunks = state._loops
+        state._loops = []
         
         outputLog("Phase: \(state.phase)")
         stateHolder.value = state

--- a/Reversi/Game.swift
+++ b/Reversi/Game.swift
@@ -114,9 +114,20 @@ private enum MainReducer: Reducer {
         let currentPhase = state.phase
 
         switch action {
-        case .executeReset:
-            // どのフェーズにいてもリセットの確認が行われたらリセット
-            state.phase = AnyPhase(ResetPhase())
+        case .reset:
+            // リセットボタンが押されたらリセット確認依頼を出す
+            state.resetConfirmationRequst = Request()
+            
+        case .resetConfirmed(let requestId, let execute):
+            if let request = state.resetConfirmationRequst, request.requestId == requestId {
+                state.resetConfirmationRequst = nil
+                
+                if execute {
+                    // どのフェーズにいてもリセットの確認の結果、
+                    // 実行することになったらリセット
+                    state.phase = AnyPhase(ResetPhase())
+                }
+            }            
             
         default:
             break

--- a/Reversi/Game.swift
+++ b/Reversi/Game.swift
@@ -18,13 +18,29 @@ public protocol Reducer {
 
 /// アクションをディスパッチするメソッドを持ちます。
 public protocol Dispatcher {
+    /// アクションらしきものをディスパッチします。
+    /// - Parameter actionish: アクションらしきもの
+    func dispatch(_ actionish: Actionish)
+    
     /// アクションをディスパッチします。
     /// - Parameter action: アクション
-    func dispatch(_ action: Action)
+    func dispatch(action: Action)
     
     /// サンクを用いてアクションをディスパッチします。
     /// - Parameter thunk: サンク
-    func dispatch(_ thunk: Thunk)
+    func dispatch(thunk: Thunk)
+}
+
+extension Dispatcher {
+    public func dispatch(_ actionish: Actionish) {
+        switch actionish {
+        case .action(let action):
+            dispatch(action: action)
+            
+        case .thunk(let thunk):
+            dispatch(thunk: thunk)
+        }
+    }
 }
 
 /// アクションのディスパッチを遅延実行させるための関数です。
@@ -84,7 +100,7 @@ public class Game: Dispatcher {
     
     /// アクションをディスパッチします。
     /// - Parameter action: ディスパッチ対象のアクション
-    public func dispatch(_ action: Action) {
+    public func dispatch(action: Action) {
         var state = stateHolder.value
         state = reducer.reduce(state: state, action: action)
 
@@ -96,13 +112,13 @@ public class Game: Dispatcher {
         stateHolder.value = state
         
         for thunk in thunks {
-            dispatch(thunk)
+            dispatch(thunk: thunk)
         }
     }
 
     /// サンクを用いてアクションをディスパッチします。
     /// - Parameter thunk: サンク
-    public func dispatch(_ thunk: Thunk) {
+    public func dispatch(thunk: Thunk) {
         thunk(self, stateHolder.value)
     }
 }

--- a/Reversi/Game.swift
+++ b/Reversi/Game.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Combine
+
+public protocol Reducer {
+    /// アクションに応じて状態を変更します。
+    /// - Parameters:
+    ///   - state: 変更前の状態です。
+    ///   - action: 状態変更を要求するアクションです。
+    /// - Returns: 変更後の状態を返します。
+    static func reduce(state: State, action: Action) -> State
+}
+
+private extension AnyPhase {
+    func reduce(state: State, action: Action) -> State {
+        return type(of: box).reduce(state: state, action: action)
+    }
+
+    func onEnter(state: State, previousPhase: AnyPhase) -> State {
+        return type(of: box).onEnter(state: state, previousPhase: previousPhase)
+    }
+    
+    func onExit(state: State, nextPhase: AnyPhase) -> State {
+        return type(of: box).onExit(state: state, nextPhase: nextPhase)
+    }
+}
+
+public enum GameError: Error {
+    case restore(data: String)
+}
+
+/// ゲームの状態を保持し、アクションをディスパッチすることでゲームを進めます。
+public class Game {
+    private let stateHolder: CurrentValueSubject<State, Never>
+
+    /// 現在の状態の発行元
+    public let statePublisher: AnyPublisher<State, Never>
+
+    /// 新規ゲームの開始状態で初期化します。
+    public convenience init() {
+        self.init(state: State(board: Board(), turn: .dark, playerModes: [.manual, .manual], phase: AnyPhase(InitialPhase())))
+    }
+
+    /// 保存した状態で初期化します。
+    /// - Parameter data: 保存状態のテキスト
+    /// - Throws: 保存状態を復元できなければ `GameError.restore` を `throw` します。
+    public convenience init(loading data: String) throws {
+        // TODO:
+        self.init()
+    }
+
+    /// 指定された状態で初期化します。
+    public init(state: State) {
+        stateHolder = CurrentValueSubject(state)
+        statePublisher = stateHolder
+            .eraseToAnyPublisher()
+    }
+
+    /// アクションをディスパッチします。
+    /// - Parameter action: ディスパッチ対象のアクション
+    func dispatch(action: Action) {
+        let currentState = stateHolder.value
+        var reducedState = MainReducer.reduce(state: currentState, action: action)
+        
+        // フェーズの遷移を処理
+        let prevPhase = currentState.phase
+        let nextPhase = reducedState.phase  
+        if prevPhase != nextPhase {
+            reducedState = prevPhase.onExit(state: reducedState, nextPhase: nextPhase)
+            assert(reducedState.phase == nextPhase, "Don't change phase by `onExit`")
+            
+            reducedState = nextPhase.onEnter(state: reducedState, previousPhase: prevPhase)
+            assert(reducedState.phase == nextPhase, "Don't change phase by `onEnter`")
+        }
+        
+        stateHolder.value = reducedState
+    }
+
+    /// 指定された関数でアクションを生成してディスパッチします。
+    /// - Parameter actionCreator: アクションを生成する関数
+    func dispatch(actionCreator: (State) -> Action?) {
+        if let action = actionCreator(stateHolder.value) {
+            dispatch(action: action)
+        }
+    }
+}
+
+private enum MainReducer: Reducer {
+    static func reduce(state: State, action: Action) -> State {
+        let currentPhase = state.phase
+        
+        var reducedState = state // TODO: ここでも何かするよね
+        
+        // フェーズが変わらなければ、フェーズにreduceさせる
+        if currentPhase == reducedState.phase {
+            reducedState = currentPhase.reduce(state: reducedState, action: action)
+        }
+        
+        return reducedState
+    }
+}

--- a/Reversi/Game.swift
+++ b/Reversi/Game.swift
@@ -21,26 +21,6 @@ public protocol Dispatcher {
     /// アクションらしきものをディスパッチします。
     /// - Parameter actionish: アクションらしきもの
     func dispatch(_ actionish: Actionish)
-    
-    /// アクションをディスパッチします。
-    /// - Parameter action: アクション
-    func dispatch(action: Action)
-    
-    /// サンクを用いてアクションをディスパッチします。
-    /// - Parameter thunk: サンク
-    func dispatch(thunk: Thunk)
-}
-
-extension Dispatcher {
-    public func dispatch(_ actionish: Actionish) {
-        switch actionish {
-        case .action(let action):
-            dispatch(action: action)
-            
-        case .thunk(let thunk):
-            dispatch(thunk: thunk)
-        }
-    }
 }
 
 /// アクションのディスパッチを遅延実行させるための関数です。
@@ -90,6 +70,18 @@ public class Game: Dispatcher {
 //        print(line())
     }
     
+    /// アクションらしきものをディスパッチします。
+    /// - Parameter actionish: アクションらしきもの
+    public func dispatch(_ actionish: Actionish) {
+        switch actionish {
+        case .action(let action):
+            dispatch(action: action)
+            
+        case .thunk(let thunk):
+            dispatch(thunk: thunk)
+        }
+    }
+
     /// アクションをディスパッチします。
     /// - Parameter action: ディスパッチ対象のアクション
     public func dispatch(action: Action) {

--- a/Reversi/Game.swift
+++ b/Reversi/Game.swift
@@ -54,9 +54,6 @@ public enum GameError: Error {
 
 /// ゲームの状態を保持し、アクションをディスパッチすることでゲームを進めます。
 public class Game: Dispatcher {
-    /// 現在進行中のゲームのインスタンス
-    public static var current: Game?
-    
     private let stateHolder: CurrentValueSubject<State, Never>
 
     /// 現在の状態の発行元
@@ -89,11 +86,6 @@ public class Game: Dispatcher {
             .eraseToAnyPublisher()
     }
 
-    /// このオブジェクトを現在進行中のGameにします。
-    public func makeCurrent() {
-        Game.current = self
-    }
-    
     private func outputLog(_ line: @autoclosure () -> String) {
 //        print(line())
     }

--- a/Reversi/GameOverPhase.swift
+++ b/Reversi/GameOverPhase.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public extension PhaseKind {
+    static let gameOver = PhaseKind(rawValue: "gameOver")
+}
+
+public struct GameOverPhase: Phase {
+    public var kind: PhaseKind { .gameOver }
+}

--- a/Reversi/GameOverPhase.swift
+++ b/Reversi/GameOverPhase.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-public extension PhaseKind {
-    static let gameOver = PhaseKind(rawValue: "gameOver")
+extension PhaseKind {
+    public static let gameOver = PhaseKind(rawValue: "gameOver")
 }
 
 public struct GameOverPhase: Phase {

--- a/Reversi/InitialPhase.swift
+++ b/Reversi/InitialPhase.swift
@@ -10,19 +10,7 @@ public struct InitialPhase: Phase {
     public func onExit(nextPhase: AnyPhase) -> Thunk? {
         // ゲームの準備が整って始まったところでいろいろ初期化する
         return { (dispatcher, _) in
-            dispatcher.dispatch(.setState { state in
-                var state = state
-                                
-                state.thinking = false
-                for disk in Disk.sides {
-                    state.diskCount[disk] = state.board.countDisks(of: disk)
-                }
-                state.boardUpdateRequest = nil
-                state.passNotificationRequest = nil
-                state.resetConfirmationRequst = nil
-
-                return state
-            })
+            dispatcher.dispatch(.initializeStateWhenStarted())
         }
     }
     

--- a/Reversi/InitialPhase.swift
+++ b/Reversi/InitialPhase.swift
@@ -7,14 +7,14 @@ extension PhaseKind {
 public struct InitialPhase: Phase {
     public var kind: PhaseKind { .initial }
 
-    public func onExit(nextPhase: AnyPhase) -> Thunk? {
+    public static func onExit(nextPhase: AnyPhase) -> Thunk? {
         // ゲームの準備が整って始まったところでいろいろ初期化する
         return { (dispatcher, _) in
             dispatcher.dispatch(.initializeStateWhenStarted())
         }
     }
     
-    public func reduce(state: State, action: Action) -> State {
+    public static func reduce(state: State, action: Action) -> State {
         var state = state
         
         switch action {

--- a/Reversi/InitialPhase.swift
+++ b/Reversi/InitialPhase.swift
@@ -31,7 +31,7 @@ public struct InitialPhase: Phase {
         
         switch action {
         case .start:
-            state.thunks.append { (dispatcher, state) in
+            state.loop { (dispatcher, state) in
                 dispatcher.dispatch(.changePhase(to: WaitForPlayerPhase()))
             }
         default:

--- a/Reversi/InitialPhase.swift
+++ b/Reversi/InitialPhase.swift
@@ -7,7 +7,7 @@ extension PhaseKind {
 public struct InitialPhase: Phase {
     public var kind: PhaseKind { .initial }
     
-    public static func reduce(state: State, action: Action) -> State {
+    public func reduce(state: State, action: Action) -> State {
         var reducedState = state
         
         switch action {

--- a/Reversi/InitialPhase.swift
+++ b/Reversi/InitialPhase.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-public extension PhaseKind {
-    static let initial = PhaseKind(rawValue: "initial")
+extension PhaseKind {
+    public static let initial = PhaseKind(rawValue: "initial")
 }
 
 public struct InitialPhase: Phase {

--- a/Reversi/InitialPhase.swift
+++ b/Reversi/InitialPhase.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public extension PhaseKind {
+    static let initial = PhaseKind(rawValue: "initial")
+}
+
+public struct InitialPhase: Phase {
+    public var kind: PhaseKind { .initial }
+    
+    public static func reduce(state: State, action: Action) -> State {
+        // TODO:
+        return state
+    }
+}

--- a/Reversi/InitialPhase.swift
+++ b/Reversi/InitialPhase.swift
@@ -6,6 +6,21 @@ extension PhaseKind {
 
 public struct InitialPhase: Phase {
     public var kind: PhaseKind { .initial }
+
+    public func onExit(state: State, nextPhase: AnyPhase) -> State {
+        var state = state
+        
+        // ゲームの準備が整って始まったところでいろいろ初期化して外部に伝える
+        state.thinking = false
+        for disk in Disk.sides {
+            state.diskCount[disk] = state.board.countDisks(of: disk)
+        }
+        state.boardUpdateRequest = nil
+        state.passNotificationRequest = nil
+        state.resetConfirmationRequst = nil
+
+        return state
+    }
     
     public func reduce(state: State, action: Action) -> State {
         var reducedState = state

--- a/Reversi/InitialPhase.swift
+++ b/Reversi/InitialPhase.swift
@@ -8,7 +8,15 @@ public struct InitialPhase: Phase {
     public var kind: PhaseKind { .initial }
     
     public static func reduce(state: State, action: Action) -> State {
-        // TODO:
-        return state
+        var reducedState = state
+        
+        switch action {
+        case .start:
+            reducedState.phase = AnyPhase(WaitForPlayerPhase())
+        default:
+            break
+        }
+        
+        return reducedState
     }
 }

--- a/Reversi/InitialPhase.swift
+++ b/Reversi/InitialPhase.swift
@@ -10,7 +10,7 @@ public struct InitialPhase: Phase {
     public func onExit(nextPhase: AnyPhase) -> Thunk? {
         // ゲームの準備が整って始まったところでいろいろ初期化する
         return { (dispatcher, _) in
-            dispatcher.dispatch(ActionCreators.setState { state in
+            dispatcher.dispatch(.setState { state in
                 var state = state
                                 
                 state.thinking = false
@@ -32,7 +32,7 @@ public struct InitialPhase: Phase {
         switch action {
         case .start:
             state.thunks.append { (dispatcher, state) in
-                dispatcher.dispatch(ActionCreators.changePhase(to: WaitForPlayerPhase()))
+                dispatcher.dispatch(.changePhase(to: WaitForPlayerPhase()))
             }
         default:
             break

--- a/Reversi/Logger.swift
+++ b/Reversi/Logger.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// フェーズとアクションに関するログ出力を行うミドルウェアです。
+public class Logger: Middleware, Dispatcher {
+    private let game: Game
+    private let next: Dispatcher
+    
+    public init(game: Game, next: Dispatcher) {
+        self.game = game
+        self.next = next
+    }
+    
+    public static func extend(game: Game, next: Dispatcher) -> Dispatcher {
+        return Logger(game: game, next: next)
+    }
+
+    public func dispatch(_ actionish: Actionish) {
+        print("(Phase: \(game.state.phase),\n Action: \(actionish))")
+        next.dispatch(actionish)
+        print("  --> Phase: \(game.state.phase)")
+    }
+}

--- a/Reversi/NextTurnPhase.swift
+++ b/Reversi/NextTurnPhase.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-public extension PhaseKind {
-    static let nextTurn = PhaseKind(rawValue: "nextTurn")
+extension PhaseKind {
+    public static let nextTurn = PhaseKind(rawValue: "nextTurn")
 }
 
 public struct NextTurnPhase: Phase {

--- a/Reversi/NextTurnPhase.swift
+++ b/Reversi/NextTurnPhase.swift
@@ -9,7 +9,7 @@ public struct NextTurnPhase: Phase {
     
     public func onEnter(previousPhase: AnyPhase) -> Thunk? {
         return { (dispatcher, state) in
-            dispatcher.dispatch(ActionCreators.setState { state in
+            dispatcher.dispatch(.setState { state in
                 var state = state
 
                 // ディスク枚数をカウント
@@ -24,18 +24,18 @@ public struct NextTurnPhase: Phase {
                         if state.board.validMoves(for: turn.flipped).isEmpty {
                             // 両方が置けなかったらゲーム終了
                             state.thunks.append { (dispatcher, _) in
-                                dispatcher.dispatch(ActionCreators.changePhase(to: GameOverPhase()))
+                                dispatcher.dispatch(.changePhase(to: GameOverPhase()))
                             }
                         } else {
                             // 相手は置けるのであれば「パス」
                             state.thunks.append { (dispatcher, _) in
-                                dispatcher.dispatch(ActionCreators.changePhase(to: PassPhase()))
+                                dispatcher.dispatch(.changePhase(to: PassPhase()))
                             }
                         }
                     } else {
                         // 置けるのなら入力待ちへ
                         state.thunks.append { (dispatcher, _) in
-                            dispatcher.dispatch(ActionCreators.changePhase(to: WaitForPlayerPhase()))
+                            dispatcher.dispatch(.changePhase(to: WaitForPlayerPhase()))
                         }                    }
                 } else {
                     // ゲーム終了しているのに NextTurnPhase に来たのがおかしい

--- a/Reversi/NextTurnPhase.swift
+++ b/Reversi/NextTurnPhase.swift
@@ -23,18 +23,18 @@ public struct NextTurnPhase: Phase {
                     if state.board.validMoves(for: turn).isEmpty {
                         if state.board.validMoves(for: turn.flipped).isEmpty {
                             // 両方が置けなかったらゲーム終了
-                            state.thunks.append { (dispatcher, _) in
+                            state.loop { (dispatcher, _) in
                                 dispatcher.dispatch(.changePhase(to: GameOverPhase()))
                             }
                         } else {
                             // 相手は置けるのであれば「パス」
-                            state.thunks.append { (dispatcher, _) in
+                            state.loop { (dispatcher, _) in
                                 dispatcher.dispatch(.changePhase(to: PassPhase()))
                             }
                         }
                     } else {
                         // 置けるのなら入力待ちへ
-                        state.thunks.append { (dispatcher, _) in
+                        state.loop { (dispatcher, _) in
                             dispatcher.dispatch(.changePhase(to: WaitForPlayerPhase()))
                         }                    }
                 } else {

--- a/Reversi/NextTurnPhase.swift
+++ b/Reversi/NextTurnPhase.swift
@@ -7,7 +7,7 @@ extension PhaseKind {
 public struct NextTurnPhase: Phase {
     public var kind: PhaseKind { .nextTurn }
     
-    public static func onEnter(state: State, previousPhase: AnyPhase) -> State {
+    public func onEnter(state: State, previousPhase: AnyPhase) -> State {
         var state = state
         
         state.turn?.flip()
@@ -32,7 +32,7 @@ public struct NextTurnPhase: Phase {
         return state
     }
     
-    public static func onExit(state: State, nextPhase: AnyPhase) -> State {
+    public func onExit(state: State, nextPhase: AnyPhase) -> State {
         // TODO: セーブ
         return state
     }

--- a/Reversi/NextTurnPhase.swift
+++ b/Reversi/NextTurnPhase.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+public extension PhaseKind {
+    static let nextTurn = PhaseKind(rawValue: "nextTurn")
+}
+
+public struct NextTurnPhase: Phase {
+    public var kind: PhaseKind { .nextTurn }
+    
+    public static func onEnter(state: State, previousPhase: AnyPhase) -> State {
+        var state = state
+        
+        state.turn?.flip()
+        
+        if let turn = state.turn {
+            if state.board.validMoves(for: turn).isEmpty {
+                if state.board.validMoves(for: turn.flipped).isEmpty {
+                    // 両方が置けなかったらゲーム終了
+                    state.phase = AnyPhase(GameOverPhase())
+                } else {
+                    // 相手は置けるのであれば「パス」
+                    state.phase = AnyPhase(PassPhase())
+                }
+            } else {
+                // 置けるのなら入力待ちへ
+                state.phase = AnyPhase(WaitForPlayerPhase())
+            }
+        } else {
+            assertionFailure()
+        }
+        
+        return state
+    }
+    
+    public static func onExit(state: State, nextPhase: AnyPhase) -> State {
+        // TODO: セーブ
+        return state
+    }
+}

--- a/Reversi/NextTurnPhase.swift
+++ b/Reversi/NextTurnPhase.swift
@@ -7,18 +7,18 @@ extension PhaseKind {
 public struct NextTurnPhase: Phase {
     public var kind: PhaseKind { .nextTurn }
     
-    public func onEnter(previousPhase: AnyPhase) -> Thunk? {
+    public static func onEnter(previousPhase: AnyPhase) -> Thunk? {
         return { (dispatcher, state) in
             dispatcher.dispatch(.nextTurn())
         }
     }
     
-    public func onExit(nextPhase: AnyPhase) -> Thunk? {
+    public static func onExit(nextPhase: AnyPhase) -> Thunk? {
         // TODO: セーブ
         return nil
     }
     
-    public func reduce(state: State, action: Action) -> State {
+    public static func reduce(state: State, action: Action) -> State {
         var state = state
         
         switch action {

--- a/Reversi/NextTurnPhase.swift
+++ b/Reversi/NextTurnPhase.swift
@@ -9,6 +9,11 @@ public struct NextTurnPhase: Phase {
     
     public func onEnter(state: State, previousPhase: AnyPhase) -> State {
         var state = state
+
+        // ディスク枚数をカウント
+        for disk in Disk.sides {
+            state.diskCount[disk] = state.board.countDisks(of: disk)
+        }
         
         state.turn?.flip()
         

--- a/Reversi/PassPhase.swift
+++ b/Reversi/PassPhase.swift
@@ -9,24 +9,15 @@ public struct PassPhase: Phase {
     
     public func onEnter(previousPhase: AnyPhase) -> Thunk? {
         return { (dispatcher, _) in
-            dispatcher.dispatch(.setState { state in
-                var state = state
-                
-                // パスの表示をゲーム外部に依頼
-                state.passNotificationRequest = Request()
-                
-                return state
-            })
+            // パスの表示をゲーム外部に依頼
+            dispatcher.dispatch(.requestPassNotification(true))
         }
     }
     
     public func onExit(state: State, nextPhase: AnyPhase) -> Thunk? {
         return { (dispatcher, _) in
-            dispatcher.dispatch(.setState { state in
-                var state = state
-                state.passNotificationRequest = nil
-                return state
-            })
+            // パス表示リクエストを取り下げ
+            dispatcher.dispatch(.requestPassNotification(false))
         }
     }
     

--- a/Reversi/PassPhase.swift
+++ b/Reversi/PassPhase.swift
@@ -37,7 +37,7 @@ public struct PassPhase: Phase {
         case .passDismissed(let requestId):
             if let request = state.passNotificationRequest, request.requestId == requestId {
                 // パス表示を消したら次のターンへ
-                state.thunks.append { (dispatcher, _) in
+                state.loop { (dispatcher, _) in
                     dispatcher.dispatch(.changePhase(to: NextTurnPhase()))
                 }
             }

--- a/Reversi/PassPhase.swift
+++ b/Reversi/PassPhase.swift
@@ -7,21 +7,21 @@ extension PhaseKind {
 public struct PassPhase: Phase {
     public var kind: PhaseKind { .pass }
     
-    public func onEnter(previousPhase: AnyPhase) -> Thunk? {
+    public static func onEnter(previousPhase: AnyPhase) -> Thunk? {
         return { (dispatcher, _) in
             // パスの表示をゲーム外部に依頼
             dispatcher.dispatch(.requestPassNotification(true))
         }
     }
     
-    public func onExit(state: State, nextPhase: AnyPhase) -> Thunk? {
+    public static func onExit(state: State, nextPhase: AnyPhase) -> Thunk? {
         return { (dispatcher, _) in
             // パス表示リクエストを取り下げ
             dispatcher.dispatch(.requestPassNotification(false))
         }
     }
     
-    public func reduce(state: State, action: Action) -> State {
+    public static func reduce(state: State, action: Action) -> State {
         var state = state
         
         switch action {

--- a/Reversi/PassPhase.swift
+++ b/Reversi/PassPhase.swift
@@ -9,7 +9,7 @@ public struct PassPhase: Phase {
     
     public func onEnter(previousPhase: AnyPhase) -> Thunk? {
         return { (dispatcher, _) in
-            dispatcher.dispatch(ActionCreators.setState { state in
+            dispatcher.dispatch(.setState { state in
                 var state = state
                 
                 // パスの表示をゲーム外部に依頼
@@ -22,7 +22,7 @@ public struct PassPhase: Phase {
     
     public func onExit(state: State, nextPhase: AnyPhase) -> Thunk? {
         return { (dispatcher, _) in
-            dispatcher.dispatch(ActionCreators.setState { state in
+            dispatcher.dispatch(.setState { state in
                 var state = state
                 state.passNotificationRequest = nil
                 return state
@@ -38,7 +38,7 @@ public struct PassPhase: Phase {
             if let request = state.passNotificationRequest, request.requestId == requestId {
                 // パス表示を消したら次のターンへ
                 state.thunks.append { (dispatcher, _) in
-                    dispatcher.dispatch(ActionCreators.changePhase(to: NextTurnPhase()))
+                    dispatcher.dispatch(.changePhase(to: NextTurnPhase()))
                 }
             }
             

--- a/Reversi/PassPhase.swift
+++ b/Reversi/PassPhase.swift
@@ -7,7 +7,7 @@ extension PhaseKind {
 public struct PassPhase: Phase {
     public var kind: PhaseKind { .pass }
     
-    public static func onEnter(state: State, previousPhase: AnyPhase) -> State {
+    public func onEnter(state: State, previousPhase: AnyPhase) -> State {
         var state = state
         
         // パスの表示をゲーム外部に依頼
@@ -16,7 +16,7 @@ public struct PassPhase: Phase {
         return state
     }
     
-    public static func onExit(state: State, nextPhase: AnyPhase) -> State {
+    public func onExit(state: State, nextPhase: AnyPhase) -> State {
         var state = state
         
         state.passNotificationRequest = nil
@@ -24,7 +24,7 @@ public struct PassPhase: Phase {
         return state
     }
     
-    public static func reduce(state: State, action: Action) -> State {
+    public func reduce(state: State, action: Action) -> State {
         var state = state
         
         switch action {

--- a/Reversi/PassPhase.swift
+++ b/Reversi/PassPhase.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-public extension PhaseKind {
-    static let pass = PhaseKind(rawValue: "pass")
+extension PhaseKind {
+    public static let pass = PhaseKind(rawValue: "pass")
 }
 
 public struct PassPhase: Phase {

--- a/Reversi/PassPhase.swift
+++ b/Reversi/PassPhase.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+public extension PhaseKind {
+    static let pass = PhaseKind(rawValue: "pass")
+}
+
+public struct PassPhase: Phase {
+    public var kind: PhaseKind { .pass }
+    
+    public static func onEnter(state: State, previousPhase: AnyPhase) -> State {
+        var state = state
+        
+        // パスの表示をゲーム外部に依頼
+        state.passNotificationRequest = Request()
+        
+        return state
+    }
+    
+    public static func reduce(state: State, action: Action) -> State {
+        var state = state
+        
+        switch action {
+        case .passNotified(let requestId):
+            if let request = state.passNotificationRequest, request.requestId == requestId {
+                state.passNotificationRequest = nil
+            }
+            
+        case .passDismissed:
+            // パス表示を消したら次のターンへ
+            state.phase = AnyPhase(NextTurnPhase())
+            
+        default:
+            break
+        }
+        
+        return state
+    }
+}

--- a/Reversi/PassPhase.swift
+++ b/Reversi/PassPhase.swift
@@ -16,18 +16,23 @@ public struct PassPhase: Phase {
         return state
     }
     
+    public static func onExit(state: State, nextPhase: AnyPhase) -> State {
+        var state = state
+        
+        state.passNotificationRequest = nil
+        
+        return state
+    }
+    
     public static func reduce(state: State, action: Action) -> State {
         var state = state
         
         switch action {
-        case .passNotified(let requestId):
+        case .passDismissed(let requestId):
             if let request = state.passNotificationRequest, request.requestId == requestId {
-                state.passNotificationRequest = nil
+                // パス表示を消したら次のターンへ
+                state.phase = AnyPhase(NextTurnPhase())
             }
-            
-        case .passDismissed:
-            // パス表示を消したら次のターンへ
-            state.phase = AnyPhase(NextTurnPhase())
             
         default:
             break

--- a/Reversi/Phase.swift
+++ b/Reversi/Phase.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// フェーズの種別を表します。
+public struct PhaseKind: Hashable {
+    private let rawValue: String
+    
+    init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+/// ゲームのフェーズを表します。
+public protocol Phase: Reducer, Hashable {
+    /// フェーズ種別です。
+    var kind: PhaseKind { get }
+    
+    /// 別のフェーズからこのフェーズに遷移するときに呼ばれます。
+    /// 必要に応じて状態を変更することができます。
+    /// - Parameters:
+    ///   - state: 現在の状態です。
+    ///   - previousPhase: 以前のフェーズが渡されます。
+    ///   -
+    static func onEnter(state: State, previousPhase: AnyPhase) -> State
+    
+    /// このフェーズから別のフェーズに遷移するときに呼ばれます。
+    /// 必要に応じて状態を変更することができます。
+    /// - Parameters:
+    ///   - state: 現在の状態です。
+    ///   - nextPhase: 次のフェーズが渡されます。
+    static func onExit(state: State, nextPhase: AnyPhase) -> State
+}
+
+extension Phase {
+    public static func onEnter(state: State, previousPhase: AnyPhase) -> State { state }
+    public static func onExit(state: State, nextPhase: AnyPhase) -> State { state }
+}
+
+/// `Phase` のtype erasureです。
+public struct AnyPhase: Phase {
+    class AnyPhaseBox {
+        var kind: PhaseKind { fatalError() }
+        
+        func isEqual(to other: AnyPhaseBox) -> Bool { fatalError() }
+        func hash(into hasher: inout Hasher) { fatalError() }
+        
+        class func reduce(state: State, action: Action) -> State { fatalError() }
+        class func onEnter(state: State, previousPhase: AnyPhase) -> State { fatalError() }
+        class func onExit(state: State, nextPhase: AnyPhase) -> State { fatalError() }
+    }
+    
+    class PhaseBox<P: Phase>: AnyPhaseBox {
+        private let base: P
+        init(_ base: P) {
+            self.base = base
+        }
+        
+        override func isEqual(to other: AnyPhaseBox) -> Bool {
+            if let other = other as? PhaseBox<P> {
+                return base == other.base
+            } else {
+                return false
+            }
+        }
+        
+        override func hash(into hasher: inout Hasher) {
+            base.hash(into: &hasher)
+        }
+        
+        override class func reduce(state: State, action: Action) -> State {
+            return P.reduce(state: state, action: action)
+        }
+        
+        override var kind: PhaseKind {
+            return base.kind
+        }
+
+        override class func onEnter(state: State, previousPhase: AnyPhase) -> State {
+            return P.onEnter(state: state, previousPhase: previousPhase)
+        }
+        
+        override class func onExit(state: State, nextPhase: AnyPhase) -> State {
+            return P.onExit(state: state, nextPhase: nextPhase)
+        }
+    }
+        
+    let box: AnyPhaseBox
+    
+    public init(_ base: AnyPhase) {
+        box = base.box
+    }
+    
+    public init<P: Phase>(_ base: P) {
+        box = PhaseBox(base)
+    }
+    
+    public static func == (lhs: AnyPhase, rhs: AnyPhase) -> Bool {
+        return lhs.box.isEqual(to: rhs.box)
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        box.hash(into: &hasher)
+    }
+
+    public static func reduce(state: State, action: Action) -> State {
+        preconditionFailure("This function should not be called.")
+    }
+    
+    public var kind: PhaseKind { box.kind }
+
+    public static func onEnter(state: State, previousPhase: AnyPhase) -> State {
+        preconditionFailure("This function should not be called.")
+    }
+    
+    public static func onExit(state: State, nextPhase: AnyPhase) -> State {
+        preconditionFailure("This function should not be called.")
+    }
+}

--- a/Reversi/Phase.swift
+++ b/Reversi/Phase.swift
@@ -1,16 +1,20 @@
 import Foundation
 
 /// フェーズの種別を表します。
-public struct PhaseKind: Hashable {
+public struct PhaseKind: Hashable, CustomStringConvertible {
     private let rawValue: String
     
     init(rawValue: String) {
         self.rawValue = rawValue
     }
+    
+    public var description: String {
+        return rawValue
+    }
 }
 
 /// ゲームのフェーズを表します。
-public protocol Phase: Reducer, Hashable {
+public protocol Phase: Reducer, Hashable, CustomStringConvertible {
     /// フェーズ種別です。
     var kind: PhaseKind { get }
     
@@ -34,10 +38,13 @@ extension Phase {
     public func onEnter(state: State, previousPhase: AnyPhase) -> State { state }
     public func onExit(state: State, nextPhase: AnyPhase) -> State { state }
     public func reduce(state: State, action: Action) -> State { state }
+    public var description: String {
+        return kind.description
+    }
 }
 
 /// `Phase` のtype erasureです。
-public struct AnyPhase: Phase {
+public struct AnyPhase: Phase, CustomStringConvertible {
     class AnyPhaseBox {
         func isEqual(to other: AnyPhaseBox) -> Bool { fatalError() }
         func hash(into hasher: inout Hasher) { fatalError() }
@@ -49,6 +56,7 @@ public struct AnyPhase: Phase {
         func onEnter(state: State, previousPhase: AnyPhase) -> State { fatalError() }
         func onExit(state: State, nextPhase: AnyPhase) -> State { fatalError() }
         
+        var description: String { fatalError() }
         var typelessBase: Any { fatalError() }
     }
     
@@ -86,6 +94,10 @@ public struct AnyPhase: Phase {
             return base.onExit(state: state, nextPhase: nextPhase)
         }
         
+        override var description: String {
+            return base.description
+        }
+        
         override var typelessBase: Any {
             return base
         }
@@ -121,6 +133,10 @@ public struct AnyPhase: Phase {
     
     public func onExit(state: State, nextPhase: AnyPhase) -> State {
         return box.onExit(state: state, nextPhase: nextPhase)
+    }
+    
+    public var description: String {
+        return box.description
     }
     
     public var base: Any {

--- a/Reversi/Phase.swift
+++ b/Reversi/Phase.swift
@@ -33,19 +33,23 @@ public protocol Phase: Reducer, Hashable {
 extension Phase {
     public static func onEnter(state: State, previousPhase: AnyPhase) -> State { state }
     public static func onExit(state: State, nextPhase: AnyPhase) -> State { state }
+    public static func reduce(state: State, action: Action) -> State { state }
 }
 
 /// `Phase` のtype erasureです。
 public struct AnyPhase: Phase {
     class AnyPhaseBox {
-        var kind: PhaseKind { fatalError() }
-        
         func isEqual(to other: AnyPhaseBox) -> Bool { fatalError() }
         func hash(into hasher: inout Hasher) { fatalError() }
         
         class func reduce(state: State, action: Action) -> State { fatalError() }
+        
+        var kind: PhaseKind { fatalError() }
+        
         class func onEnter(state: State, previousPhase: AnyPhase) -> State { fatalError() }
         class func onExit(state: State, nextPhase: AnyPhase) -> State { fatalError() }
+        
+        var typelessBase: Any { fatalError() }
     }
     
     class PhaseBox<P: Phase>: AnyPhaseBox {
@@ -81,6 +85,10 @@ public struct AnyPhase: Phase {
         override class func onExit(state: State, nextPhase: AnyPhase) -> State {
             return P.onExit(state: state, nextPhase: nextPhase)
         }
+        
+        override var typelessBase: Any {
+            return base
+        }
     }
         
     let box: AnyPhaseBox
@@ -113,5 +121,9 @@ public struct AnyPhase: Phase {
     
     public static func onExit(state: State, nextPhase: AnyPhase) -> State {
         preconditionFailure("This function should not be called.")
+    }
+    
+    public var base: Any {
+        return box.typelessBase
     }
 }

--- a/Reversi/Phase.swift
+++ b/Reversi/Phase.swift
@@ -20,20 +20,20 @@ public protocol Phase: Reducer, Hashable {
     ///   - state: 現在の状態です。
     ///   - previousPhase: 以前のフェーズが渡されます。
     ///   -
-    static func onEnter(state: State, previousPhase: AnyPhase) -> State
+    func onEnter(state: State, previousPhase: AnyPhase) -> State
     
     /// このフェーズから別のフェーズに遷移するときに呼ばれます。
     /// 必要に応じて状態を変更することができます。
     /// - Parameters:
     ///   - state: 現在の状態です。
     ///   - nextPhase: 次のフェーズが渡されます。
-    static func onExit(state: State, nextPhase: AnyPhase) -> State
+    func onExit(state: State, nextPhase: AnyPhase) -> State
 }
 
 extension Phase {
-    public static func onEnter(state: State, previousPhase: AnyPhase) -> State { state }
-    public static func onExit(state: State, nextPhase: AnyPhase) -> State { state }
-    public static func reduce(state: State, action: Action) -> State { state }
+    public func onEnter(state: State, previousPhase: AnyPhase) -> State { state }
+    public func onExit(state: State, nextPhase: AnyPhase) -> State { state }
+    public func reduce(state: State, action: Action) -> State { state }
 }
 
 /// `Phase` のtype erasureです。
@@ -42,12 +42,12 @@ public struct AnyPhase: Phase {
         func isEqual(to other: AnyPhaseBox) -> Bool { fatalError() }
         func hash(into hasher: inout Hasher) { fatalError() }
         
-        class func reduce(state: State, action: Action) -> State { fatalError() }
+        func reduce(state: State, action: Action) -> State { fatalError() }
         
         var kind: PhaseKind { fatalError() }
         
-        class func onEnter(state: State, previousPhase: AnyPhase) -> State { fatalError() }
-        class func onExit(state: State, nextPhase: AnyPhase) -> State { fatalError() }
+        func onEnter(state: State, previousPhase: AnyPhase) -> State { fatalError() }
+        func onExit(state: State, nextPhase: AnyPhase) -> State { fatalError() }
         
         var typelessBase: Any { fatalError() }
     }
@@ -70,20 +70,20 @@ public struct AnyPhase: Phase {
             base.hash(into: &hasher)
         }
         
-        override class func reduce(state: State, action: Action) -> State {
-            return P.reduce(state: state, action: action)
+        override func reduce(state: State, action: Action) -> State {
+            return base.reduce(state: state, action: action)
         }
         
         override var kind: PhaseKind {
             return base.kind
         }
 
-        override class func onEnter(state: State, previousPhase: AnyPhase) -> State {
-            return P.onEnter(state: state, previousPhase: previousPhase)
+        override func onEnter(state: State, previousPhase: AnyPhase) -> State {
+            return base.onEnter(state: state, previousPhase: previousPhase)
         }
         
-        override class func onExit(state: State, nextPhase: AnyPhase) -> State {
-            return P.onExit(state: state, nextPhase: nextPhase)
+        override func onExit(state: State, nextPhase: AnyPhase) -> State {
+            return base.onExit(state: state, nextPhase: nextPhase)
         }
         
         override var typelessBase: Any {
@@ -109,18 +109,18 @@ public struct AnyPhase: Phase {
         box.hash(into: &hasher)
     }
 
-    public static func reduce(state: State, action: Action) -> State {
-        preconditionFailure("This function should not be called.")
+    public func reduce(state: State, action: Action) -> State {
+        return box.reduce(state: state, action: action)
     }
     
     public var kind: PhaseKind { box.kind }
 
-    public static func onEnter(state: State, previousPhase: AnyPhase) -> State {
-        preconditionFailure("This function should not be called.")
+    public func onEnter(state: State, previousPhase: AnyPhase) -> State {
+        return box.onEnter(state: state, previousPhase: previousPhase)
     }
     
-    public static func onExit(state: State, nextPhase: AnyPhase) -> State {
-        preconditionFailure("This function should not be called.")
+    public func onExit(state: State, nextPhase: AnyPhase) -> State {
+        return box.onExit(state: state, nextPhase: nextPhase)
     }
     
     public var base: Any {

--- a/Reversi/PlaceDiskPhase.swift
+++ b/Reversi/PlaceDiskPhase.swift
@@ -18,22 +18,30 @@ public struct PlaceDiskPhase: Phase {
         return "\(kind.description)(x=\(x), y=\(y))"
     }
 
-    public func onEnter(state: State, previousPhase: AnyPhase) -> State {
-        var state = state
-        
-        // ボードにディスクを置く。その変更分は `PlacingDiskPhase` で反映。
-        if let turn = state.turn {
-            if let cellChanges = try? state.board.placeDisk(turn, atX: self.x , y: self.y) {
-                // 置けたら
-                state.phase = AnyPhase(PlacingDiskPhase(cellChanges: cellChanges[...]))
+    public func onEnter(previousPhase: AnyPhase) -> Thunk? {
+        return { (dispatcher, state) in
+            // ボードにディスクを置く。その変更分は `PlacingDiskPhase` で反映。
+            if let turn = state.turn {
+                dispatcher.dispatch(ActionCreators.setState { state in
+                    var state = state
+                    if let cellChanges = try? state.board.placeDisk(turn, atX: self.x , y: self.y) {
+                        // 置けたら
+                        state.thunks.append { (dispatcher, _) in
+                            dispatcher.dispatch(ActionCreators.changePhase(to: PlacingDiskPhase(cellChanges: cellChanges[...])))
+                        }
+                    } else {
+                        // 置けなかったら `ThinkingPhase` へ
+                        state.thunks.append { (dispatcher, _) in
+                            dispatcher.dispatch(ActionCreators.changePhase(to: ThinkingPhase()))
+                        }
+                    }
+                    return state
+                })
             } else {
-                // 置けなかったら `ThinkingPhase` へ
-                state.phase = AnyPhase(ThinkingPhase())
+                // ゲームが終了しているのにPlaceDiskPhaseに来たということなのでおかしい
+                assertionFailure()
             }
-        } else {
-            assertionFailure()
+
         }
-        
-        return state
     }
 }

--- a/Reversi/PlaceDiskPhase.swift
+++ b/Reversi/PlaceDiskPhase.swift
@@ -22,17 +22,17 @@ public struct PlaceDiskPhase: Phase {
         return { (dispatcher, state) in
             // ボードにディスクを置く。その変更分は `PlacingDiskPhase` で反映。
             if let turn = state.turn {
-                dispatcher.dispatch(ActionCreators.setState { state in
+                dispatcher.dispatch(.setState { state in
                     var state = state
                     if let cellChanges = try? state.board.placeDisk(turn, atX: self.x , y: self.y) {
                         // 置けたら
                         state.thunks.append { (dispatcher, _) in
-                            dispatcher.dispatch(ActionCreators.changePhase(to: PlacingDiskPhase(cellChanges: cellChanges[...])))
+                            dispatcher.dispatch(.changePhase(to: PlacingDiskPhase(cellChanges: cellChanges[...])))
                         }
                     } else {
                         // 置けなかったら `ThinkingPhase` へ
                         state.thunks.append { (dispatcher, _) in
-                            dispatcher.dispatch(ActionCreators.changePhase(to: ThinkingPhase()))
+                            dispatcher.dispatch(.changePhase(to: ThinkingPhase()))
                         }
                     }
                     return state

--- a/Reversi/PlaceDiskPhase.swift
+++ b/Reversi/PlaceDiskPhase.swift
@@ -26,12 +26,12 @@ public struct PlaceDiskPhase: Phase {
                     var state = state
                     if let cellChanges = try? state.board.placeDisk(turn, atX: self.x , y: self.y) {
                         // 置けたら
-                        state.thunks.append { (dispatcher, _) in
+                        state.loop { (dispatcher, _) in
                             dispatcher.dispatch(.changePhase(to: PlacingDiskPhase(cellChanges: cellChanges[...])))
                         }
                     } else {
                         // 置けなかったら `ThinkingPhase` へ
-                        state.thunks.append { (dispatcher, _) in
+                        state.loop { (dispatcher, _) in
                             dispatcher.dispatch(.changePhase(to: ThinkingPhase()))
                         }
                     }

--- a/Reversi/PlaceDiskPhase.swift
+++ b/Reversi/PlaceDiskPhase.swift
@@ -18,20 +18,22 @@ public struct PlaceDiskPhase: Phase {
         return "\(kind.description)(x=\(x), y=\(y))"
     }
 
-    public func onEnter(previousPhase: AnyPhase) -> Thunk? {
+    public static func onEnter(previousPhase: AnyPhase) -> Thunk? {
         return { (dispatcher, state) in
-            // ボードにディスクを置く。その変更分は `PlacingDiskPhase` で反映。
-            if let turn = state.turn {
-                dispatcher.dispatch(.placeDisk(disk: turn, x: self.x, y: self.y))
-            } else {
+            guard let turn = state.turn else {
                 // ゲームが終了しているのにPlaceDiskPhaseに来たということなのでおかしい
                 assertionFailure()
+                return
             }
 
+            // ボードにディスクを置く。その変更分は `PlacingDiskPhase` で反映。
+            if let phase = thisPhase(of: state) {
+                dispatcher.dispatch(.placeDisk(disk: turn, x: phase.x, y: phase.y))
+            }
         }
     }
     
-    public func reduce(state: State, action: Action) -> State {
+    public static func reduce(state: State, action: Action) -> State {
         var state = state
         
         switch action {

--- a/Reversi/PlaceDiskPhase.swift
+++ b/Reversi/PlaceDiskPhase.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-public extension PhaseKind {
-    static let placeDisk = PhaseKind(rawValue: "placeDisk")
+extension PhaseKind {
+    public static let placeDisk = PhaseKind(rawValue: "placeDisk")
 }
 
 public struct PlaceDiskPhase: Phase {

--- a/Reversi/PlaceDiskPhase.swift
+++ b/Reversi/PlaceDiskPhase.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+public extension PhaseKind {
+    static let placeDisk = PhaseKind(rawValue: "placeDisk")
+}
+
+public struct PlaceDiskPhase: Phase {
+    private let x: Int
+    private let y: Int
+    
+    public init(x: Int, y: Int) {
+        self.x = x
+        self.y = y
+    }
+    
+    public var kind: PhaseKind { .placeDisk }
+    
+    public static func onEnter(state: State, previousPhase: AnyPhase) -> State {
+        var state = state
+        
+        // ボードにディスクを置く。その変更分は `PlacingDiskPhase` で反映。
+        if let turn = state.turn {
+            let phase = state.phase.base as! PlaceDiskPhase
+            if let cellChanges = try? state.board.placeDisk(turn, atX: phase.x , y: phase.y) {
+                // 置けたら
+                state.phase = AnyPhase(PlacingDiskPhase(cellChanges: cellChanges[...]))
+            }
+        }
+        
+        return state
+    }
+}

--- a/Reversi/PlaceDiskPhase.swift
+++ b/Reversi/PlaceDiskPhase.swift
@@ -15,13 +15,12 @@ public struct PlaceDiskPhase: Phase {
     
     public var kind: PhaseKind { .placeDisk }
     
-    public static func onEnter(state: State, previousPhase: AnyPhase) -> State {
+    public func onEnter(state: State, previousPhase: AnyPhase) -> State {
         var state = state
         
         // ボードにディスクを置く。その変更分は `PlacingDiskPhase` で反映。
         if let turn = state.turn {
-            let phase = state.phase.base as! PlaceDiskPhase
-            if let cellChanges = try? state.board.placeDisk(turn, atX: phase.x , y: phase.y) {
+            if let cellChanges = try? state.board.placeDisk(turn, atX: self.x , y: self.y) {
                 // 置けたら
                 state.phase = AnyPhase(PlacingDiskPhase(cellChanges: cellChanges[...]))
             }

--- a/Reversi/PlaceDiskPhase.swift
+++ b/Reversi/PlaceDiskPhase.swift
@@ -23,7 +23,12 @@ public struct PlaceDiskPhase: Phase {
             if let cellChanges = try? state.board.placeDisk(turn, atX: self.x , y: self.y) {
                 // 置けたら
                 state.phase = AnyPhase(PlacingDiskPhase(cellChanges: cellChanges[...]))
+            } else {
+                // 置けなかったら `ThinkingPhase` へ
+                state.phase = AnyPhase(ThinkingPhase())
             }
+        } else {
+            assertionFailure()
         }
         
         return state

--- a/Reversi/PlaceDiskPhase.swift
+++ b/Reversi/PlaceDiskPhase.swift
@@ -14,7 +14,10 @@ public struct PlaceDiskPhase: Phase {
     }
     
     public var kind: PhaseKind { .placeDisk }
-    
+    public var description: String {
+        return "\(kind.description)(x=\(x), y=\(y))"
+    }
+
     public func onEnter(state: State, previousPhase: AnyPhase) -> State {
         var state = state
         

--- a/Reversi/PlacingDiskPhase.swift
+++ b/Reversi/PlacingDiskPhase.swift
@@ -49,7 +49,7 @@ public struct PlacingDiskPhase: Phase {
         case .boardUpdated(let requestId):
             if let request = state.boardUpdateRequest, request.requestId == requestId {
                 // 残りの変更の反映を依頼するフェーズへ
-                state.thunks.append { (dispatcher, _) in
+                state.loop { (dispatcher, _) in
                     dispatcher.dispatch(.changePhase(to: PlacingDiskPhase(cellChanges: self.cellChanges[self.cellChanges.startIndex.advanced(by: 1)...])))
                 }
             }

--- a/Reversi/PlacingDiskPhase.swift
+++ b/Reversi/PlacingDiskPhase.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+public extension PhaseKind {
+    static let placingDisk = PhaseKind(rawValue: "placingDisk")
+}
+
+public struct PlacingDiskPhase: Phase {
+    private let cellChanges: ArraySlice<Board.CellChange>
+    
+    public init(cellChanges: ArraySlice<Board.CellChange>) {
+        self.cellChanges = cellChanges
+    }
+    
+    public var kind: PhaseKind { .placingDisk }
+    
+    public static func onEnter(state: State, previousPhase: AnyPhase) -> State {
+        var state = state
+        
+        // 1つ目を取り出して、ゲーム外部に更新を依頼
+        let phase = state.phase.base as! PlacingDiskPhase
+        if let change = phase.cellChanges.first {
+            state.boardUpdateRequest = Request(.withAnimation(change))
+        } else {
+            // 反映するものがなくなったら、次のターンへ
+            state.phase = AnyPhase(NextTurnPhase())
+        }
+        
+        return state
+    }
+    
+    public static func reduce(state: State, action: Action) -> State {
+        var state = state
+        
+        switch action {
+        case .boardUpdated(let requestId):
+            if let request = state.boardUpdateRequest, request.requestId == requestId {
+                // この依頼が反映された
+                state.boardUpdateRequest = nil
+                
+                // 残りの変更の反映を依頼するフェーズへ
+                let phase = state.phase.base as! PlacingDiskPhase
+                state.phase = AnyPhase(PlacingDiskPhase(cellChanges: phase.cellChanges[1...]))
+            }
+            
+        default:
+            break
+        }
+        
+        return state
+    }
+}

--- a/Reversi/PlacingDiskPhase.swift
+++ b/Reversi/PlacingDiskPhase.swift
@@ -28,15 +28,20 @@ public struct PlacingDiskPhase: Phase {
         return state
     }
     
+    public static func onExit(state: State, nextPhase: AnyPhase) -> State {
+        var state = state
+
+        state.boardUpdateRequest = nil
+        
+        return state
+    }
+    
     public static func reduce(state: State, action: Action) -> State {
         var state = state
         
         switch action {
         case .boardUpdated(let requestId):
             if let request = state.boardUpdateRequest, request.requestId == requestId {
-                // この依頼が反映された
-                state.boardUpdateRequest = nil
-                
                 // 残りの変更の反映を依頼するフェーズへ
                 let phase = state.phase.base as! PlacingDiskPhase
                 state.phase = AnyPhase(PlacingDiskPhase(cellChanges: phase.cellChanges[1...]))

--- a/Reversi/PlacingDiskPhase.swift
+++ b/Reversi/PlacingDiskPhase.swift
@@ -20,11 +20,7 @@ public struct PlacingDiskPhase: Phase {
         return { (dispatcher, state) in
             // 1つ目を取り出して、ゲーム外部に更新を依頼
             if let change = self.cellChanges.first {
-                dispatcher.dispatch(.setState { state in
-                    var state = state
-                    state.boardUpdateRequest = DetailedRequest(.withAnimation(change))
-                    return state
-                })
+                dispatcher.dispatch(.requestUpdateBoard(request: DetailedRequest(.withAnimation(change))))
             } else {
                 // 反映するものがなくなったら、次のターンへ
                 dispatcher.dispatch(.changePhase(to: NextTurnPhase()))
@@ -34,11 +30,7 @@ public struct PlacingDiskPhase: Phase {
     
     public func onExit(nextPhase: AnyPhase) -> Thunk? {
         return { (dispatcher, state) in
-            dispatcher.dispatch(.setState { state in
-                var state = state
-                state.boardUpdateRequest = nil
-                return state
-            })
+            dispatcher.dispatch(.requestUpdateBoard(request: nil))
         }
     }
     

--- a/Reversi/PlacingDiskPhase.swift
+++ b/Reversi/PlacingDiskPhase.swift
@@ -20,21 +20,21 @@ public struct PlacingDiskPhase: Phase {
         return { (dispatcher, state) in
             // 1つ目を取り出して、ゲーム外部に更新を依頼
             if let change = self.cellChanges.first {
-                dispatcher.dispatch(ActionCreators.setState { state in
+                dispatcher.dispatch(.setState { state in
                     var state = state
                     state.boardUpdateRequest = DetailedRequest(.withAnimation(change))
                     return state
                 })
             } else {
                 // 反映するものがなくなったら、次のターンへ
-                dispatcher.dispatch(ActionCreators.changePhase(to: NextTurnPhase()))
+                dispatcher.dispatch(.changePhase(to: NextTurnPhase()))
             }
         }
     }
     
     public func onExit(nextPhase: AnyPhase) -> Thunk? {
         return { (dispatcher, state) in
-            dispatcher.dispatch(ActionCreators.setState { state in
+            dispatcher.dispatch(.setState { state in
                 var state = state
                 state.boardUpdateRequest = nil
                 return state
@@ -50,7 +50,7 @@ public struct PlacingDiskPhase: Phase {
             if let request = state.boardUpdateRequest, request.requestId == requestId {
                 // 残りの変更の反映を依頼するフェーズへ
                 state.thunks.append { (dispatcher, _) in
-                    dispatcher.dispatch(ActionCreators.changePhase(to: PlacingDiskPhase(cellChanges: self.cellChanges[self.cellChanges.startIndex.advanced(by: 1)...])))
+                    dispatcher.dispatch(.changePhase(to: PlacingDiskPhase(cellChanges: self.cellChanges[self.cellChanges.startIndex.advanced(by: 1)...])))
                 }
             }
             

--- a/Reversi/PlacingDiskPhase.swift
+++ b/Reversi/PlacingDiskPhase.swift
@@ -12,13 +12,16 @@ public struct PlacingDiskPhase: Phase {
     }
     
     public var kind: PhaseKind { .placingDisk }
-    
+    public var description: String {
+        return "\(kind.description)(\(cellChanges.count) change(s) left)"
+    }
+
     public func onEnter(state: State, previousPhase: AnyPhase) -> State {
         var state = state
         
         // 1つ目を取り出して、ゲーム外部に更新を依頼
         if let change = self.cellChanges.first {
-            state.boardUpdateRequest = Request(.withAnimation(change))
+            state.boardUpdateRequest = DetailedRequest(.withAnimation(change))
         } else {
             // 反映するものがなくなったら、次のターンへ
             state.phase = AnyPhase(NextTurnPhase())
@@ -42,7 +45,7 @@ public struct PlacingDiskPhase: Phase {
         case .boardUpdated(let requestId):
             if let request = state.boardUpdateRequest, request.requestId == requestId {
                 // 残りの変更の反映を依頼するフェーズへ
-                state.phase = AnyPhase(PlacingDiskPhase(cellChanges: self.cellChanges[1...]))
+                state.phase = AnyPhase(PlacingDiskPhase(cellChanges: self.cellChanges[self.cellChanges.startIndex.advanced(by: 1)...]))
             }
             
         default:

--- a/Reversi/PlacingDiskPhase.swift
+++ b/Reversi/PlacingDiskPhase.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-public extension PhaseKind {
-    static let placingDisk = PhaseKind(rawValue: "placingDisk")
+extension PhaseKind {
+    public static let placingDisk = PhaseKind(rawValue: "placingDisk")
 }
 
 public struct PlacingDiskPhase: Phase {

--- a/Reversi/PlacingDiskPhase.swift
+++ b/Reversi/PlacingDiskPhase.swift
@@ -13,12 +13,11 @@ public struct PlacingDiskPhase: Phase {
     
     public var kind: PhaseKind { .placingDisk }
     
-    public static func onEnter(state: State, previousPhase: AnyPhase) -> State {
+    public func onEnter(state: State, previousPhase: AnyPhase) -> State {
         var state = state
         
         // 1つ目を取り出して、ゲーム外部に更新を依頼
-        let phase = state.phase.base as! PlacingDiskPhase
-        if let change = phase.cellChanges.first {
+        if let change = self.cellChanges.first {
             state.boardUpdateRequest = Request(.withAnimation(change))
         } else {
             // 反映するものがなくなったら、次のターンへ
@@ -28,7 +27,7 @@ public struct PlacingDiskPhase: Phase {
         return state
     }
     
-    public static func onExit(state: State, nextPhase: AnyPhase) -> State {
+    public func onExit(state: State, nextPhase: AnyPhase) -> State {
         var state = state
 
         state.boardUpdateRequest = nil
@@ -36,15 +35,14 @@ public struct PlacingDiskPhase: Phase {
         return state
     }
     
-    public static func reduce(state: State, action: Action) -> State {
+    public func reduce(state: State, action: Action) -> State {
         var state = state
         
         switch action {
         case .boardUpdated(let requestId):
             if let request = state.boardUpdateRequest, request.requestId == requestId {
                 // 残りの変更の反映を依頼するフェーズへ
-                let phase = state.phase.base as! PlacingDiskPhase
-                state.phase = AnyPhase(PlacingDiskPhase(cellChanges: phase.cellChanges[1...]))
+                state.phase = AnyPhase(PlacingDiskPhase(cellChanges: self.cellChanges[1...]))
             }
             
         default:

--- a/Reversi/PlayerMode.swift
+++ b/Reversi/PlayerMode.swift
@@ -4,23 +4,3 @@ public enum PlayerMode: Hashable {
     case manual
     case computer
 }
-
-extension Array where Element == PlayerMode {
-    public subscript(_ disk: Disk) -> PlayerMode {
-        get {
-            return self[disk.index]
-        }
-        set {
-            self[disk.index] = newValue
-        }
-    }
-}
-
-extension Disk {
-    fileprivate var index: Int {
-        switch self {
-        case .dark: return 0
-        case .light: return 1
-        }
-    }
-}

--- a/Reversi/PlayerMode.swift
+++ b/Reversi/PlayerMode.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public enum PlayerMode: Hashable {
+    case manual
+    case computer
+}
+
+extension Array where Element == PlayerMode {
+    public subscript(_ disk: Disk) -> PlayerMode {
+        get {
+            return self[disk.index]
+        }
+        set {
+            self[disk.index] = newValue
+        }
+    }
+}
+
+extension Disk {
+    fileprivate var index: Int {
+        switch self {
+        case .dark: return 0
+        case .light: return 1
+        }
+    }
+}

--- a/Reversi/ResetPhase.swift
+++ b/Reversi/ResetPhase.swift
@@ -7,7 +7,7 @@ extension PhaseKind {
 public struct ResetPhase: Phase {
     public var kind: PhaseKind { .reset }
     
-    public static func onEnter(state: State, previousPhase: AnyPhase) -> State {
+    public func onEnter(state: State, previousPhase: AnyPhase) -> State {
         var state = state
         
         // リセットして、入力待ちフェーズへ遷移
@@ -20,7 +20,7 @@ public struct ResetPhase: Phase {
         return state
     }
     
-    public static func onExit(state: State, nextPhase: AnyPhase) -> State {
+    public func onExit(state: State, nextPhase: AnyPhase) -> State {
         // TODO: セーブ
         return state
     }

--- a/Reversi/ResetPhase.swift
+++ b/Reversi/ResetPhase.swift
@@ -12,7 +12,7 @@ public struct ResetPhase: Phase {
         
         // リセットして、入力待ちフェーズへ遷移
         let cellChanges = state.board.reset()
-        state.boardUpdateRequest = Request(.withoutAnimation(cellChanges))
+        state.boardUpdateRequest = DetailedRequest(.withoutAnimation(cellChanges))
         state.turn = .dark
         state.playerModes = state.playerModes.map { _ in .manual }
         state.phase = AnyPhase(WaitForPlayerPhase())

--- a/Reversi/ResetPhase.swift
+++ b/Reversi/ResetPhase.swift
@@ -7,18 +7,18 @@ extension PhaseKind {
 public struct ResetPhase: Phase {
     public var kind: PhaseKind { .reset }
     
-    public func onEnter(previousPhase: AnyPhase) -> Thunk? {
+    public static func onEnter(previousPhase: AnyPhase) -> Thunk? {
         return { (dispatcher, _) in
             dispatcher.dispatch(.doReset())
         }
     }
     
-    public func onExit(nextPhase: AnyPhase) -> Thunk? {
+    public static func onExit(nextPhase: AnyPhase) -> Thunk? {
         // TODO: セーブ
         return nil
     }
     
-    public func reduce(state: State, action: Action) -> State {
+    public static func reduce(state: State, action: Action) -> State {
         var state = state
         
         switch action {

--- a/Reversi/ResetPhase.swift
+++ b/Reversi/ResetPhase.swift
@@ -7,28 +7,32 @@ extension PhaseKind {
 public struct ResetPhase: Phase {
     public var kind: PhaseKind { .reset }
     
-    public func onEnter(state: State, previousPhase: AnyPhase) -> State {
-        var state = state
-        
-        // リセットして、入力待ちフェーズへ遷移
-        let cellChanges = state.board.reset()
-        state.boardUpdateRequest = DetailedRequest(.withoutAnimation(cellChanges))
-        state.turn = .dark
-        state.playerModes = state.playerModes.map { _ in .manual }
-        state.phase = AnyPhase(WaitForPlayerPhase())
-        state.thinking = false
-        for disk in Disk.sides {
-            state.diskCount[disk] = state.board.countDisks(of: disk)
-        }
-        state.boardUpdateRequest = nil
-        state.passNotificationRequest = nil
-        state.resetConfirmationRequst = nil
+    public func onEnter(previousPhase: AnyPhase) -> Thunk? {
+        return { (dispatcher, _) in
+            dispatcher.dispatch(ActionCreators.setState { state in
+                var state = state
+                
+                // リセットして、入力待ちフェーズへ遷移
+                let cellChanges = state.board.reset()
+                state.boardUpdateRequest = DetailedRequest(.withoutAnimation(cellChanges))
+                state.turn = .dark
+                state.playerModes = state.playerModes.map { _ in .manual }
+                state.thinking = false
+                for disk in Disk.sides {
+                    state.diskCount[disk] = state.board.countDisks(of: disk)
+                }
+                state.boardUpdateRequest = nil
+                state.passNotificationRequest = nil
+                state.resetConfirmationRequst = nil
 
-        return state
+                return state
+            })
+            dispatcher.dispatch(ActionCreators.changePhase(to: WaitForPlayerPhase()))
+        }
     }
     
-    public func onExit(state: State, nextPhase: AnyPhase) -> State {
+    public func onExit(nextPhase: AnyPhase) -> Thunk? {
         // TODO: セーブ
-        return state
+        return nil
     }
 }

--- a/Reversi/ResetPhase.swift
+++ b/Reversi/ResetPhase.swift
@@ -9,7 +9,7 @@ public struct ResetPhase: Phase {
     
     public func onEnter(previousPhase: AnyPhase) -> Thunk? {
         return { (dispatcher, _) in
-            dispatcher.dispatch(ActionCreators.setState { state in
+            dispatcher.dispatch(.setState { state in
                 var state = state
                 
                 // リセットして、入力待ちフェーズへ遷移
@@ -27,7 +27,7 @@ public struct ResetPhase: Phase {
 
                 return state
             })
-            dispatcher.dispatch(ActionCreators.changePhase(to: WaitForPlayerPhase()))
+            dispatcher.dispatch(.changePhase(to: WaitForPlayerPhase()))
         }
     }
     

--- a/Reversi/ResetPhase.swift
+++ b/Reversi/ResetPhase.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-public extension PhaseKind {
-    static let reset = PhaseKind(rawValue: "reset")
+extension PhaseKind {
+    public static let reset = PhaseKind(rawValue: "reset")
 }
 
 public struct ResetPhase: Phase {

--- a/Reversi/ResetPhase.swift
+++ b/Reversi/ResetPhase.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public extension PhaseKind {
+    static let reset = PhaseKind(rawValue: "reset")
+}
+
+public struct ResetPhase: Phase {
+    public var kind: PhaseKind { .reset }
+    
+    public static func onEnter(state: State, previousPhase: AnyPhase) -> State {
+        var state = state
+        
+        // リセットして、入力待ちフェーズへ遷移
+        let cellChanges = state.board.reset()
+        state.boardUpdateRequest = Request(.withoutAnimation(cellChanges))
+        state.turn = .dark
+        state.playerModes = state.playerModes.map { _ in .manual }
+        state.phase = AnyPhase(WaitForPlayerPhase())
+
+        return state
+    }
+    
+    public static func onExit(state: State, nextPhase: AnyPhase) -> State {
+        // TODO: セーブ
+        return state
+    }
+}

--- a/Reversi/ResetPhase.swift
+++ b/Reversi/ResetPhase.swift
@@ -16,6 +16,13 @@ public struct ResetPhase: Phase {
         state.turn = .dark
         state.playerModes = state.playerModes.map { _ in .manual }
         state.phase = AnyPhase(WaitForPlayerPhase())
+        state.thinking = false
+        for disk in Disk.sides {
+            state.diskCount[disk] = state.board.countDisks(of: disk)
+        }
+        state.boardUpdateRequest = nil
+        state.passNotificationRequest = nil
+        state.resetConfirmationRequst = nil
 
         return state
     }

--- a/Reversi/State.swift
+++ b/Reversi/State.swift
@@ -13,6 +13,14 @@ public struct State {
     
     /// ゲームのフェーズです。
     public var phase: AnyPhase
+
+    /// リバーシ盤の表示を更新する依頼が出ていれば値が設定されています。
+    /// 依頼に答えたら `Action.boardUpdated` をディスパッチしてください。
+    public var boardUpdateRequest: Request<BoardUpdate>?
+
+    /// 「パス」を通知する依頼が出ていれば値が設定されています。
+    /// 依頼に答えたら `Action.passNotified` をディスパッチしてください。
+    public var passNotificationRequest: Request<Void>?
     
     public init(board: Board, turn: Disk?, playerModes: [PlayerMode], phase: AnyPhase) {
         precondition(playerModes.count == Disk.sides.count)
@@ -23,3 +31,32 @@ public struct State {
         self.phase = phase
     }
 }
+
+/// ゲーム外部に出す依頼
+public struct Request<D> {
+    /// 依頼の番号
+    public let requestId = UniqueIdentifier()
+    
+    /// 依頼の詳細
+    public let detail: D
+    
+    public init(_ detail: D) {
+        self.detail = detail
+    }
+}
+
+extension Request where D == Void {
+    public init() {
+        self.init(())
+    }
+}
+
+/// リバーシ盤の表示更新の依頼内容
+public enum BoardUpdate {
+    /// 「1つのセルをアニメーション付きで更新してください」という依頼
+    case withAnimation(Board.CellChange)
+    
+    /// 「一連のセルをアニメーションなしで更新してください」という依頼
+    case withoutAnimation([Board.CellChange])
+}
+

--- a/Reversi/State.swift
+++ b/Reversi/State.swift
@@ -12,7 +12,13 @@ public struct State {
     public var playerModes: [PlayerMode]
     
     /// ゲームのフェーズです。
-    public var phase: AnyPhase
+    public var phase: AnyPhase = AnyPhase(InitialPhase())
+    
+    /// コンピューターが思考中に true になります。
+    public var thinking: Bool = false
+    
+    /// プレイヤーごとのディスク枚数です。
+    public var diskCount: [Int] = Disk.sides.map { _ in 0 }
 
     /// リバーシ盤の表示を更新する依頼が出ていれば値が設定されています。
     /// 依頼に答えたら `Action.boardUpdated` をディスパッチしてください。
@@ -26,13 +32,12 @@ public struct State {
     /// 依頼に答えて確認結果が得られたら `Action.resetConfirmed` をディスパッチしてください。
     public var resetConfirmationRequst: Request<Void>?    
     
-    public init(board: Board, turn: Disk?, playerModes: [PlayerMode], phase: AnyPhase) {
+    public init(board: Board, turn: Disk?, playerModes: [PlayerMode]) {
         precondition(playerModes.count == Disk.sides.count)
         
         self.board = board
         self.turn = turn
         self.playerModes = playerModes
-        self.phase = phase
     }
 }
 

--- a/Reversi/State.swift
+++ b/Reversi/State.swift
@@ -39,6 +39,9 @@ public struct State {
         self.turn = turn
         self.playerModes = playerModes
     }
+    
+    /// のちのタイミングでディスパッチされるサンクです。
+    public var thunks: [Thunk] = []
 }
 
 /// ゲーム外部に出す依頼

--- a/Reversi/State.swift
+++ b/Reversi/State.swift
@@ -22,15 +22,15 @@ public struct State {
 
     /// リバーシ盤の表示を更新する依頼が出ていれば値が設定されています。
     /// 依頼に答えたら `Action.boardUpdated` をディスパッチしてください。
-    public var boardUpdateRequest: Request<BoardUpdate>?
+    public var boardUpdateRequest: DetailedRequest<BoardUpdate>?
 
     /// 「パス」を通知する依頼が出ていれば値が設定されています。
     /// 依頼に答えて通知が閉じられたら `Action.passDismissed` をディスパッチしてください。
-    public var passNotificationRequest: Request<Void>?
+    public var passNotificationRequest: Request?
     
     /// リセットの確認を表示する依頼が出ていれば値が設定されています。
     /// 依頼に答えて確認結果が得られたら `Action.resetConfirmed` をディスパッチしてください。
-    public var resetConfirmationRequst: Request<Void>?    
+    public var resetConfirmationRequst: Request?    
     
     public init(board: Board, turn: Disk?, playerModes: [PlayerMode]) {
         precondition(playerModes.count == Disk.sides.count)
@@ -42,7 +42,13 @@ public struct State {
 }
 
 /// ゲーム外部に出す依頼
-public struct Request<D> {
+public struct Request: Hashable {
+    /// 依頼の番号
+    public let requestId = UniqueIdentifier()
+}
+
+/// ゲーム外部に出す依頼（詳細付き）
+public struct DetailedRequest<D: Hashable>: Hashable {
     /// 依頼の番号
     public let requestId = UniqueIdentifier()
     
@@ -54,14 +60,8 @@ public struct Request<D> {
     }
 }
 
-extension Request where D == Void {
-    public init() {
-        self.init(())
-    }
-}
-
 /// リバーシ盤の表示更新の依頼内容
-public enum BoardUpdate {
+public enum BoardUpdate: Hashable {
     /// 「1つのセルをアニメーション付きで更新してください」という依頼
     case withAnimation(Board.CellChange)
     

--- a/Reversi/State.swift
+++ b/Reversi/State.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// ゲームの状態です。
+public struct State {
+    /// リバーシ盤の状態です。
+    public var board: Board
+    
+    /// 現在のターンを表します。ゲームが終了したときは `nil` になります。
+    public var turn: Disk?
+    
+    /// プレイヤーのモードです。
+    public var playerModes: [PlayerMode]
+    
+    /// ゲームのフェーズです。
+    public var phase: AnyPhase
+    
+    public init(board: Board, turn: Disk?, playerModes: [PlayerMode], phase: AnyPhase) {
+        precondition(playerModes.count == Disk.sides.count)
+        
+        self.board = board
+        self.turn = turn
+        self.playerModes = playerModes
+        self.phase = phase
+    }
+}

--- a/Reversi/State.swift
+++ b/Reversi/State.swift
@@ -40,8 +40,16 @@ public struct State {
         self.playerModes = playerModes
     }
     
+    /// のちのタイミングでディスパッチしてほしいサンクを登録します。
+    public mutating func loop(thunk: @escaping Thunk) {
+        _loops.append(thunk)
+    }
+    
     /// のちのタイミングでディスパッチされるサンクです。
-    public var thunks: [Thunk] = []
+    /// これは本来のStateの一部ではありません。
+    /// `loop` を実現するために `State` に場所を間借りしているもので、
+    /// このプロパティの値は状態として記録されるべきではありません。
+    public var _loops: [Thunk] = []
 }
 
 /// ゲーム外部に出す依頼

--- a/Reversi/State.swift
+++ b/Reversi/State.swift
@@ -19,8 +19,12 @@ public struct State {
     public var boardUpdateRequest: Request<BoardUpdate>?
 
     /// 「パス」を通知する依頼が出ていれば値が設定されています。
-    /// 依頼に答えたら `Action.passNotified` をディスパッチしてください。
+    /// 依頼に答えて通知が閉じられたら `Action.passDismissed` をディスパッチしてください。
     public var passNotificationRequest: Request<Void>?
+    
+    /// リセットの確認を表示する依頼が出ていれば値が設定されています。
+    /// 依頼に答えて確認結果が得られたら `Action.resetConfirmed` をディスパッチしてください。
+    public var resetConfirmationRequst: Request<Void>?    
     
     public init(board: Board, turn: Disk?, playerModes: [PlayerMode], phase: AnyPhase) {
         precondition(playerModes.count == Disk.sides.count)

--- a/Reversi/State.swift
+++ b/Reversi/State.swift
@@ -21,15 +21,15 @@ public struct State {
     public var diskCount: [Int] = Disk.sides.map { _ in 0 }
 
     /// リバーシ盤の表示を更新する依頼が出ていれば値が設定されています。
-    /// 依頼に答えたら `Action.boardUpdated` をディスパッチしてください。
+    /// 依頼に答えたら `Actionish.boardUpdated()` の結果をディスパッチしてください。
     public var boardUpdateRequest: DetailedRequest<BoardUpdate>?
 
     /// 「パス」を通知する依頼が出ていれば値が設定されています。
-    /// 依頼に答えて通知が閉じられたら `Action.passDismissed` をディスパッチしてください。
+    /// 依頼に答えて通知が閉じられたら `Actionish.passDismissed()` の結果をディスパッチしてください。
     public var passNotificationRequest: Request?
     
     /// リセットの確認を表示する依頼が出ていれば値が設定されています。
-    /// 依頼に答えて確認結果が得られたら `Action.resetConfirmed` をディスパッチしてください。
+    /// 依頼に答えて確認結果が得られたら `Actionish.resetConfirmed()` の結果をディスパッチしてください。
     public var resetConfirmationRequst: Request?    
     
     public init(board: Board, turn: Disk?, playerModes: [PlayerMode]) {

--- a/Reversi/ThinkingPhase.swift
+++ b/Reversi/ThinkingPhase.swift
@@ -18,7 +18,7 @@ public struct ThinkingPhase: Phase {
         return { (dispatcher, state) in
             if let turn = state.turn {
                 // 思考を開始
-                dispatcher.dispatch(ActionCreators.setState { state in
+                dispatcher.dispatch(.setState { state in
                     var state = state
                     state.thinking = true
                     return state
@@ -28,7 +28,7 @@ public struct ThinkingPhase: Phase {
                     // 実はもう打つ手は決まったのだが、もったいぶって（？）
                     // 時間を置いてから打つ
                     DispatchQueue.main.asyncAfter(deadline: .now() + ThinkingPhase.thinkingDuration) {
-                        dispatcher.dispatch({ (dispatcher, state) in
+                        dispatcher.dispatch(thunk: { (dispatcher, state) in
                             // 時間をつぶして戻ってきてもまだこのフェーズにいるときだけ打つ。
                             if let phase = state.phase.base as? ThinkingPhase, phase.thinkingId == self.thinkingId {
                                 dispatcher.dispatch(.boardCellSelected(x: x, y: y))
@@ -48,7 +48,7 @@ public struct ThinkingPhase: Phase {
     
     public func onExit(nextPhase: AnyPhase) -> Thunk? {
         return { (dispatcher, state) in
-            dispatcher.dispatch(ActionCreators.setState { state in
+            dispatcher.dispatch(.setState { state in
                 var state = state
                 state.thinking = false
                 return state
@@ -65,13 +65,13 @@ public struct ThinkingPhase: Phase {
                 // 現在の対象のプレイヤーがマニュアルに変更されたら
                 // 入力待ちフェーズへ遷移
                 state.thunks.append { (dispatcher, _) in
-                    dispatcher.dispatch(ActionCreators.changePhase(to: WaitForPlayerPhase()))
+                    dispatcher.dispatch(.changePhase(to: WaitForPlayerPhase()))
                 }
             }
             
         case .boardCellSelected(x: let x, y: let y):
             state.thunks.append { (dispatcher, _) in
-                dispatcher.dispatch(ActionCreators.changePhase(to: PlaceDiskPhase(x: x, y: y)))
+                dispatcher.dispatch(.changePhase(to: PlaceDiskPhase(x: x, y: y)))
             }
             
         default:

--- a/Reversi/ThinkingPhase.swift
+++ b/Reversi/ThinkingPhase.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+public extension PhaseKind {
+    static let thinking = PhaseKind(rawValue: "thinking")
+}
+
+public struct ThinkingPhase: Phase {
+    private let thinkingId = UniqueIdentifier()
+    private let thinkingDuration: Double
+    
+    public init(thinkingDuration: Double = 2.0) {
+        self.thinkingDuration = thinkingDuration
+    }
+    
+    public var kind: PhaseKind { .thinking }
+    
+    public static func onEnter(state: State, previousPhase: AnyPhase) -> State {
+        if let turn = state.turn {
+            // 思考を開始
+            if let (x, y) = state.board.validMoves(for: turn).randomElement() {
+                // 実はもう打つ手は決まったのだが、もったいぶって（？）
+                // 時間を置いてから打つ
+                let phase = state.phase.base as! ThinkingPhase
+                let currentId = phase.thinkingId
+                DispatchQueue.main.asyncAfter(deadline: .now() + phase.thinkingDuration) {
+                    if let game = Game.current {
+                        game.dispatch { state in
+                            // 時間をつぶして戻ってきてもまだこのフェーズにいるときだけ打つ。
+                            if let phase = state.phase.base as? ThinkingPhase, phase.thinkingId == currentId {
+                                return .boardCellSelected(x: x, y: y)
+                            }
+                            return nil
+                        }
+                    }
+                }
+            }
+        }
+
+        return state
+    }
+    
+    public static func reduce(state: State, action: Action) -> State {
+        var state = state
+        
+        switch action {
+        case .playerModeChanged(player: let player, mode: let mode):
+            if let turn = state.turn, turn == player && mode == .manual {
+                // 現在の対象のプレイヤーがマニュアルに変更されたら
+                // 入力待ちフェーズへ遷移
+                state.phase = AnyPhase(WaitForPlayerPhase())
+            }
+            
+        case .boardCellSelected(x: let x, y: let y):
+            state.phase = AnyPhase(PlaceDiskPhase(x: x, y: y))
+            
+        default:
+            break
+        }
+        
+        return state
+    }
+}

--- a/Reversi/ThinkingPhase.swift
+++ b/Reversi/ThinkingPhase.swift
@@ -14,42 +14,46 @@ public struct ThinkingPhase: Phase {
         return "\(kind.description)(thinkingId=\(thinkingId))"
     }
     
-    public func onEnter(previousPhase: AnyPhase) -> Thunk? {
+    public static func onEnter(previousPhase: AnyPhase) -> Thunk? {
         return { (dispatcher, state) in
-            if let turn = state.turn {
-                // 思考を開始
-                dispatcher.dispatch(.setThinking(true))
-                
-                if let (x, y) = state.board.validMoves(for: turn).randomElement() {
-                    // 実はもう打つ手は決まったのだが、もったいぶって（？）
-                    // 時間を置いてから打つ
-                    DispatchQueue.main.asyncAfter(deadline: .now() + ThinkingPhase.thinkingDuration) {
-                        dispatcher.dispatch(.thunk({ (dispatcher, state) in
-                            // 時間をつぶして戻ってきてもまだこのフェーズにいるときだけ打つ。
-                            if let phase = state.phase.base as? ThinkingPhase, phase.thinkingId == self.thinkingId {
-                                dispatcher.dispatch(.boardCellSelected(x: x, y: y))
-                            }
-                        }))
-                    }
-                } else {
-                    // 打つところがないのにThinkingPhaseになったということなのでおかしい
-                    assertionFailure()
-                }
-            } else {
+            guard let turn = state.turn else {
                 // ゲームが終了しているのにThinkingPhaseになったということなのでおかしい
                 assertionFailure()
+                return
+            }
+            
+            // 思考を開始
+            dispatcher.dispatch(.setThinking(true))
+            
+            guard let (x, y) = state.board.validMoves(for: turn).randomElement() else {
+                // 打つところがないのにThinkingPhaseになったということなのでおかしい
+                assertionFailure()
+                return
+            }
+            
+            // 実はもう打つ手は決まったのだが、もったいぶって（？）
+            // 時間を置いてから打つ
+            if let thinkingId = thisPhase(of: state)?.thinkingId {
+                DispatchQueue.main.asyncAfter(deadline: .now() + ThinkingPhase.thinkingDuration) {
+                    dispatcher.dispatch(.thunk({ (dispatcher, state) in
+                        // 時間をつぶして戻ってきてもまだこのフェーズにいるときだけ打つ。
+                        if let phase = thisPhase(of: state), phase.thinkingId == thinkingId {
+                            dispatcher.dispatch(.boardCellSelected(x: x, y: y))
+                        }
+                    }))
+                }
             }
         }
     }
     
-    public func onExit(nextPhase: AnyPhase) -> Thunk? {
+    public static func onExit(nextPhase: AnyPhase) -> Thunk? {
         return { (dispatcher, state) in
             // 思考を終了
             dispatcher.dispatch(.setThinking(false))
         }
     }
     
-    public func reduce(state: State, action: Action) -> State {
+    public static func reduce(state: State, action: Action) -> State {
         var state = state
         
         switch action {

--- a/Reversi/ThinkingPhase.swift
+++ b/Reversi/ThinkingPhase.swift
@@ -24,12 +24,12 @@ public struct ThinkingPhase: Phase {
                     // 実はもう打つ手は決まったのだが、もったいぶって（？）
                     // 時間を置いてから打つ
                     DispatchQueue.main.asyncAfter(deadline: .now() + ThinkingPhase.thinkingDuration) {
-                        dispatcher.dispatch(thunk: { (dispatcher, state) in
+                        dispatcher.dispatch(.thunk({ (dispatcher, state) in
                             // 時間をつぶして戻ってきてもまだこのフェーズにいるときだけ打つ。
                             if let phase = state.phase.base as? ThinkingPhase, phase.thinkingId == self.thinkingId {
                                 dispatcher.dispatch(.boardCellSelected(x: x, y: y))
                             }
-                        })
+                        }))
                     }
                 } else {
                     // 打つところがないのにThinkingPhaseになったということなのでおかしい

--- a/Reversi/ThinkingPhase.swift
+++ b/Reversi/ThinkingPhase.swift
@@ -18,11 +18,7 @@ public struct ThinkingPhase: Phase {
         return { (dispatcher, state) in
             if let turn = state.turn {
                 // 思考を開始
-                dispatcher.dispatch(.setState { state in
-                    var state = state
-                    state.thinking = true
-                    return state
-                })
+                dispatcher.dispatch(.setThinking(true))
                 
                 if let (x, y) = state.board.validMoves(for: turn).randomElement() {
                     // 実はもう打つ手は決まったのだが、もったいぶって（？）
@@ -48,11 +44,8 @@ public struct ThinkingPhase: Phase {
     
     public func onExit(nextPhase: AnyPhase) -> Thunk? {
         return { (dispatcher, state) in
-            dispatcher.dispatch(.setState { state in
-                var state = state
-                state.thinking = false
-                return state
-            })
+            // 思考を終了
+            dispatcher.dispatch(.setThinking(false))
         }
     }
     

--- a/Reversi/ThinkingPhase.swift
+++ b/Reversi/ThinkingPhase.swift
@@ -5,15 +5,21 @@ extension PhaseKind {
 }
 
 public struct ThinkingPhase: Phase {
-    private static var thinkingDuration: Double = 2.0
+    public static var thinkingDuration: Double = 2.0
     
     private let thinkingId = UniqueIdentifier()
     
     public var kind: PhaseKind { .thinking }
+    public var description: String {
+        return "\(kind.description)(thinkingId=\(thinkingId))"
+    }
     
     public func onEnter(state: State, previousPhase: AnyPhase) -> State {
+        var state = state
+        
         if let turn = state.turn {
             // 思考を開始
+            state.thinking = true
             if let (x, y) = state.board.validMoves(for: turn).randomElement() {
                 // 実はもう打つ手は決まったのだが、もったいぶって（？）
                 // 時間を置いてから打つ
@@ -32,6 +38,14 @@ public struct ThinkingPhase: Phase {
         } else {
             assertionFailure()
         }
+        
+        return state
+    }
+    
+    public func onExit(state: State, nextPhase: AnyPhase) -> State {
+        var state = state
+
+        state.thinking = false
         
         return state
     }

--- a/Reversi/ThinkingPhase.swift
+++ b/Reversi/ThinkingPhase.swift
@@ -5,12 +5,9 @@ extension PhaseKind {
 }
 
 public struct ThinkingPhase: Phase {
-    private let thinkingId = UniqueIdentifier()
-    private let thinkingDuration: Double
+    private static var thinkingDuration: Double = 2.0
     
-    public init(thinkingDuration: Double = 2.0) {
-        self.thinkingDuration = thinkingDuration
-    }
+    private let thinkingId = UniqueIdentifier()
     
     public var kind: PhaseKind { .thinking }
     
@@ -20,7 +17,7 @@ public struct ThinkingPhase: Phase {
             if let (x, y) = state.board.validMoves(for: turn).randomElement() {
                 // 実はもう打つ手は決まったのだが、もったいぶって（？）
                 // 時間を置いてから打つ
-                DispatchQueue.main.asyncAfter(deadline: .now() + self.thinkingDuration) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + ThinkingPhase.thinkingDuration) {
                     if let game = Game.current {
                         game.dispatch { state in
                             // 時間をつぶして戻ってきてもまだこのフェーズにいるときだけ打つ。
@@ -32,6 +29,8 @@ public struct ThinkingPhase: Phase {
                     }
                 }
             }
+        } else {
+            assertionFailure()
         }
         
         return state

--- a/Reversi/ThinkingPhase.swift
+++ b/Reversi/ThinkingPhase.swift
@@ -14,19 +14,17 @@ public struct ThinkingPhase: Phase {
     
     public var kind: PhaseKind { .thinking }
     
-    public static func onEnter(state: State, previousPhase: AnyPhase) -> State {
+    public func onEnter(state: State, previousPhase: AnyPhase) -> State {
         if let turn = state.turn {
             // 思考を開始
             if let (x, y) = state.board.validMoves(for: turn).randomElement() {
                 // 実はもう打つ手は決まったのだが、もったいぶって（？）
                 // 時間を置いてから打つ
-                let phase = state.phase.base as! ThinkingPhase
-                let currentId = phase.thinkingId
-                DispatchQueue.main.asyncAfter(deadline: .now() + phase.thinkingDuration) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + self.thinkingDuration) {
                     if let game = Game.current {
                         game.dispatch { state in
                             // 時間をつぶして戻ってきてもまだこのフェーズにいるときだけ打つ。
-                            if let phase = state.phase.base as? ThinkingPhase, phase.thinkingId == currentId {
+                            if let phase = state.phase.base as? ThinkingPhase, phase.thinkingId == self.thinkingId {
                                 return .boardCellSelected(x: x, y: y)
                             }
                             return nil
@@ -35,11 +33,11 @@ public struct ThinkingPhase: Phase {
                 }
             }
         }
-
+        
         return state
     }
     
-    public static func reduce(state: State, action: Action) -> State {
+    public func reduce(state: State, action: Action) -> State {
         var state = state
         
         switch action {

--- a/Reversi/ThinkingPhase.swift
+++ b/Reversi/ThinkingPhase.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-public extension PhaseKind {
-    static let thinking = PhaseKind(rawValue: "thinking")
+extension PhaseKind {
+    public static let thinking = PhaseKind(rawValue: "thinking")
 }
 
 public struct ThinkingPhase: Phase {

--- a/Reversi/ThinkingPhase.swift
+++ b/Reversi/ThinkingPhase.swift
@@ -64,13 +64,13 @@ public struct ThinkingPhase: Phase {
             if let turn = state.turn, turn == player && mode == .manual {
                 // 現在の対象のプレイヤーがマニュアルに変更されたら
                 // 入力待ちフェーズへ遷移
-                state.thunks.append { (dispatcher, _) in
+                state.loop { (dispatcher, _) in
                     dispatcher.dispatch(.changePhase(to: WaitForPlayerPhase()))
                 }
             }
             
         case .boardCellSelected(x: let x, y: let y):
-            state.thunks.append { (dispatcher, _) in
+            state.loop { (dispatcher, _) in
                 dispatcher.dispatch(.changePhase(to: PlaceDiskPhase(x: x, y: y)))
             }
             

--- a/Reversi/ThinkingPhase.swift
+++ b/Reversi/ThinkingPhase.swift
@@ -14,40 +14,46 @@ public struct ThinkingPhase: Phase {
         return "\(kind.description)(thinkingId=\(thinkingId))"
     }
     
-    public func onEnter(state: State, previousPhase: AnyPhase) -> State {
-        var state = state
-        
-        if let turn = state.turn {
-            // 思考を開始
-            state.thinking = true
-            if let (x, y) = state.board.validMoves(for: turn).randomElement() {
-                // 実はもう打つ手は決まったのだが、もったいぶって（？）
-                // 時間を置いてから打つ
-                DispatchQueue.main.asyncAfter(deadline: .now() + ThinkingPhase.thinkingDuration) {
-                    if let game = Game.current {
-                        game.dispatch { state in
+    public func onEnter(previousPhase: AnyPhase) -> Thunk? {
+        return { (dispatcher, state) in
+            if let turn = state.turn {
+                // 思考を開始
+                dispatcher.dispatch(ActionCreators.setState { state in
+                    var state = state
+                    state.thinking = true
+                    return state
+                })
+                
+                if let (x, y) = state.board.validMoves(for: turn).randomElement() {
+                    // 実はもう打つ手は決まったのだが、もったいぶって（？）
+                    // 時間を置いてから打つ
+                    DispatchQueue.main.asyncAfter(deadline: .now() + ThinkingPhase.thinkingDuration) {
+                        dispatcher.dispatch({ (dispatcher, state) in
                             // 時間をつぶして戻ってきてもまだこのフェーズにいるときだけ打つ。
                             if let phase = state.phase.base as? ThinkingPhase, phase.thinkingId == self.thinkingId {
-                                return .boardCellSelected(x: x, y: y)
+                                dispatcher.dispatch(.boardCellSelected(x: x, y: y))
                             }
-                            return nil
-                        }
+                        })
                     }
+                } else {
+                    // 打つところがないのにThinkingPhaseになったということなのでおかしい
+                    assertionFailure()
                 }
+            } else {
+                // ゲームが終了しているのにThinkingPhaseになったということなのでおかしい
+                assertionFailure()
             }
-        } else {
-            assertionFailure()
         }
-        
-        return state
     }
     
-    public func onExit(state: State, nextPhase: AnyPhase) -> State {
-        var state = state
-
-        state.thinking = false
-        
-        return state
+    public func onExit(nextPhase: AnyPhase) -> Thunk? {
+        return { (dispatcher, state) in
+            dispatcher.dispatch(ActionCreators.setState { state in
+                var state = state
+                state.thinking = false
+                return state
+            })
+        }
     }
     
     public func reduce(state: State, action: Action) -> State {
@@ -58,11 +64,15 @@ public struct ThinkingPhase: Phase {
             if let turn = state.turn, turn == player && mode == .manual {
                 // 現在の対象のプレイヤーがマニュアルに変更されたら
                 // 入力待ちフェーズへ遷移
-                state.phase = AnyPhase(WaitForPlayerPhase())
+                state.thunks.append { (dispatcher, _) in
+                    dispatcher.dispatch(ActionCreators.changePhase(to: WaitForPlayerPhase()))
+                }
             }
             
         case .boardCellSelected(x: let x, y: let y):
-            state.phase = AnyPhase(PlaceDiskPhase(x: x, y: y))
+            state.thunks.append { (dispatcher, _) in
+                dispatcher.dispatch(ActionCreators.changePhase(to: PlaceDiskPhase(x: x, y: y)))
+            }
             
         default:
             break

--- a/Reversi/UniqueIdentifier.swift
+++ b/Reversi/UniqueIdentifier.swift
@@ -1,12 +1,22 @@
 import Foundation
 
-private var lastIdentifier = 0
+private var lastIdentifier: UInt = 0
 
 /// 一意のID
-public struct UniqueIdentifier: Hashable {
-    private let rawValue: Int
+public struct UniqueIdentifier: Hashable, CustomStringConvertible {
+    private let rawValue: UInt
     public init() {
         lastIdentifier += 1 // ここでオーバーフローしたらごめんね
-        self.rawValue = lastIdentifier
+        self.init(rawValue: lastIdentifier)
     }
+    
+    private init(rawValue: UInt) {
+        self.rawValue = rawValue
+    }
+    
+    public var description: String {
+        return "ID:\(rawValue)"
+    }
+    
+    public static let invalid = UniqueIdentifier(rawValue: 0)
 }

--- a/Reversi/UniqueIdentifier.swift
+++ b/Reversi/UniqueIdentifier.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+private var lastIdentifier = 0
+
+/// 一意のID
+public struct UniqueIdentifier: Hashable {
+    private let rawValue: Int
+    public init() {
+        lastIdentifier += 1 // ここでオーバーフローしたらごめんね
+        self.rawValue = lastIdentifier
+    }
+}

--- a/Reversi/ViewController.swift
+++ b/Reversi/ViewController.swift
@@ -432,7 +432,7 @@ final class Canceller {
 // MARK: File-private extensions
 
 extension Disk {
-    init(index: Int) {
+    fileprivate init(index: Int) {
         for side in Disk.sides {
             if index == side.index {
                 self = side
@@ -442,7 +442,7 @@ extension Disk {
         preconditionFailure("Illegal index: \(index)")
     }
     
-    var index: Int {
+    fileprivate var index: Int {
         switch self {
         case .dark: return 0
         case .light: return 1

--- a/Reversi/WaitForPlayerPhase.swift
+++ b/Reversi/WaitForPlayerPhase.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public extension PhaseKind {
+    static let waitForPlayer = PhaseKind(rawValue: "waitForPlayer")
+}
+
+public struct WaitForPlayerPhase: Phase {
+    public var kind: PhaseKind { .waitForPlayer }
+    
+    public static func onEnter(state: State, previousPhase: AnyPhase) -> State {
+        var state = state
+        
+        // このターンがコンピューターに任せられているのなら
+        // コンピューターの思考フェーズへ遷移させる
+        if let turn = state.turn, state.playerModes[turn] == .computer {
+            state.phase = AnyPhase(ThinkingPhase())
+        }
+        
+        return state
+    }
+    
+    public static func reduce(state: State, action: Action) -> State {
+        var state = state
+        
+        switch action {
+        case .boardCellSelected(x: let x, y: let y):
+            state.phase = AnyPhase(PlaceDiskPhase(x: x, y: y))
+            
+        default:
+            break
+        }
+        
+        return state
+    }
+}

--- a/Reversi/WaitForPlayerPhase.swift
+++ b/Reversi/WaitForPlayerPhase.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-public extension PhaseKind {
-    static let waitForPlayer = PhaseKind(rawValue: "waitForPlayer")
+extension PhaseKind {
+    public static let waitForPlayer = PhaseKind(rawValue: "waitForPlayer")
 }
 
 public struct WaitForPlayerPhase: Phase {

--- a/Reversi/WaitForPlayerPhase.swift
+++ b/Reversi/WaitForPlayerPhase.swift
@@ -12,7 +12,7 @@ public struct WaitForPlayerPhase: Phase {
             // このターンがコンピューターに任せられているのなら
             // コンピューターの思考フェーズへ遷移させる
             if let turn = state.turn, state.playerModes[turn] == .computer {
-                dispatcher.dispatch(ActionCreators.changePhase(to: ThinkingPhase()))
+                dispatcher.dispatch(.changePhase(to: ThinkingPhase()))
             }
         }
     }
@@ -23,7 +23,7 @@ public struct WaitForPlayerPhase: Phase {
         switch action {
         case .boardCellSelected(x: let x, y: let y):
             state.thunks.append { (dispatcher, _) in
-                dispatcher.dispatch(ActionCreators.changePhase(to: PlaceDiskPhase(x: x, y: y)))
+                dispatcher.dispatch(.changePhase(to: PlaceDiskPhase(x: x, y: y)))
             }
             
         default:

--- a/Reversi/WaitForPlayerPhase.swift
+++ b/Reversi/WaitForPlayerPhase.swift
@@ -7,7 +7,7 @@ extension PhaseKind {
 public struct WaitForPlayerPhase: Phase {
     public var kind: PhaseKind { .waitForPlayer }
     
-    public static func onEnter(state: State, previousPhase: AnyPhase) -> State {
+    public func onEnter(state: State, previousPhase: AnyPhase) -> State {
         var state = state
         
         // このターンがコンピューターに任せられているのなら
@@ -19,7 +19,7 @@ public struct WaitForPlayerPhase: Phase {
         return state
     }
     
-    public static func reduce(state: State, action: Action) -> State {
+    public func reduce(state: State, action: Action) -> State {
         var state = state
         
         switch action {

--- a/Reversi/WaitForPlayerPhase.swift
+++ b/Reversi/WaitForPlayerPhase.swift
@@ -7,7 +7,7 @@ extension PhaseKind {
 public struct WaitForPlayerPhase: Phase {
     public var kind: PhaseKind { .waitForPlayer }
     
-    public func onEnter(previousPhase: AnyPhase) -> Thunk? {
+    public static func onEnter(previousPhase: AnyPhase) -> Thunk? {
         return { (dispatcher, state) in
             // このターンがコンピューターに任せられているのなら
             // コンピューターの思考フェーズへ遷移させる
@@ -17,7 +17,7 @@ public struct WaitForPlayerPhase: Phase {
         }
     }
     
-    public func reduce(state: State, action: Action) -> State {
+    public static func reduce(state: State, action: Action) -> State {
         var state = state
         
         switch action {

--- a/Reversi/WaitForPlayerPhase.swift
+++ b/Reversi/WaitForPlayerPhase.swift
@@ -22,7 +22,7 @@ public struct WaitForPlayerPhase: Phase {
         
         switch action {
         case .boardCellSelected(x: let x, y: let y):
-            state.thunks.append { (dispatcher, _) in
+            state.loop { (dispatcher, _) in
                 dispatcher.dispatch(.changePhase(to: PlaceDiskPhase(x: x, y: y)))
             }
             

--- a/ReversiTests/EventuallyFulfill.swift
+++ b/ReversiTests/EventuallyFulfill.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Combine
+import XCTest
+
+/// どこかのタイミングで結果的に指定したチェッカーを満たす状態になったら
+/// その時点で指定された `expectation` を `fulfill()` する `Subscriber` です。
+class EventuallyFulfill<Input, Failure: Error>: Subscriber, Cancellable {
+    typealias Input = Input
+    typealias Failure = Failure
+    
+    private var subscription: Subscription?
+    private var expectation: XCTestExpectation?
+    private var inputChecker: (Input) -> Bool
+    private var errorChecker: (Failure) -> Bool
+    private var isFulfilled = false
+     
+    public init(_ expectation: XCTestExpectation? = nil, inputChecker: @escaping (Input) -> Bool = { _ in false }, errorChecker: @escaping (Failure) -> Bool = { _ in false }) {
+        self.expectation = expectation
+        self.inputChecker = inputChecker
+        self.errorChecker = errorChecker
+    }
+
+    public func reset(_ expectation: XCTestExpectation, inputChecker: @escaping (Input) -> Bool = { _ in false }, errorChecker: @escaping (Failure) -> Bool = { _ in false }) {
+        self.expectation = expectation
+        self.inputChecker = inputChecker
+        self.errorChecker = errorChecker
+        isFulfilled = false
+    }
+    
+    func receive(subscription: Subscription) {
+        self.subscription = subscription
+        subscription.request(.unlimited)
+    }
+    
+    func receive(_ input: Input) -> Subscribers.Demand {
+        if let expectation = expectation, !isFulfilled && inputChecker(input) {
+            expectation.fulfill()
+            isFulfilled = true
+        }
+        
+        return .unlimited
+    }
+    
+    func receive(completion: Subscribers.Completion<Failure>) {
+        switch completion {
+        case .failure(let error):
+            if let expectation = expectation, !isFulfilled && errorChecker(error) {
+                expectation.fulfill()
+                isFulfilled = true
+            }
+            
+        case .finished:
+            break
+        }
+    }
+
+    func cancel() {
+        subscription?.cancel()
+        subscription = nil
+    }
+}

--- a/ReversiTests/GameTests.swift
+++ b/ReversiTests/GameTests.swift
@@ -44,7 +44,7 @@ class GameTests: XCTestCase {
     }
     
     func testGameStartToNextTurn() {
-        let game = Game()
+        let game = Game(middlewares: [Logger.self])
 
         let stateSubscriber = EventuallyFulfill<State, Never>()
         game.statePublisher.subscribe(stateSubscriber)
@@ -156,7 +156,7 @@ class GameTests: XCTestCase {
         ThinkingPhase.thinkingDuration = 0.5
         
         let state = State(board: Board(), turn: .dark, playerModes: [.computer, .computer])
-        let game = Game(state: state)
+        let game = Game(state: state, middlewares: [Logger.self])
 
         let stateSubscriber = EventuallyFulfill<State, Never>()
         let publisher = game

--- a/ReversiTests/GameTests.swift
+++ b/ReversiTests/GameTests.swift
@@ -45,7 +45,6 @@ class GameTests: XCTestCase {
     
     func testGameStartToNextTurn() {
         let game = Game()
-        game.makeCurrent()
 
         let stateSubscriber = EventuallyFulfill<State, Never>()
         game.statePublisher.subscribe(stateSubscriber)
@@ -158,7 +157,6 @@ class GameTests: XCTestCase {
         
         let state = State(board: Board(), turn: .dark, playerModes: [.computer, .computer])
         let game = Game(state: state)
-        game.makeCurrent()
 
         let stateSubscriber = EventuallyFulfill<State, Never>()
         let publisher = game

--- a/ReversiTests/GameTests.swift
+++ b/ReversiTests/GameTests.swift
@@ -1,15 +1,270 @@
 import XCTest
+import Combine
 @testable import Reversi
 
+extension PhaseKind {
+    fileprivate static let test1 = PhaseKind(rawValue: "test1")
+    fileprivate static let test2 = PhaseKind(rawValue: "test2")
+}
+
 class GameTests: XCTestCase {
+    var cancellables = Set<AnyCancellable>()
+    
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        cancellables = Set<AnyCancellable>()
     }
 
     override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        for cancellable in cancellables {
+            cancellable.cancel()
+        }
+        cancellables = []
     }
 
-    
+    func testStatePublisher() {
+        struct TestPhase1: Phase {
+            public var kind: PhaseKind { .test1 }
+        }
+        
+        var state = State(board: Board(), turn: .dark, playerModes: [.manual, .manual])
+        state.phase = AnyPhase(TestPhase1())
 
+        let game = Game(state: state)
+        
+        let exp = expectation(description: "waiting for phase test1")
+        game.statePublisher
+            .sink { state in
+                if state.phase.kind == .test1 {
+                    exp.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+        
+        wait(for: [exp], timeout: 3.0)
+    }
+    
+    func testPhaseChange() {
+        struct TestPhase1: Phase {
+            let enterExpectation: XCTestExpectation
+            let exitExpectation:  XCTestExpectation
+
+            init(enterExpectation: XCTestExpectation, exitExpectation: XCTestExpectation) {
+                self.enterExpectation = enterExpectation
+                self.exitExpectation = exitExpectation
+            }
+            
+            public var kind: PhaseKind { .test1 }
+            
+            func onEnter(state: State, previousPhase: AnyPhase) -> State {
+                self.enterExpectation.fulfill()
+                return state
+            }
+            
+            func onExit(state: State, nextPhase: AnyPhase) -> State {
+                self.exitExpectation.fulfill()
+                return state
+            }
+            
+            func reduce(state: State, action: Action) -> State {
+                var state = state
+
+                // なんでもいいのでアクションが来たらTestPhase2へ遷移
+                state.phase = AnyPhase(TestPhase2())
+                
+                return state
+            }
+        }
+        struct TestPhase2: Phase {
+            public var kind: PhaseKind { .test2 }
+        }
+
+        let test1Enter = expectation(description: "onEnter of test1")
+        test1Enter.isInverted = true
+        
+        let test1Exit = expectation(description: "onExit of test1")
+
+        let phase = TestPhase1(enterExpectation: test1Enter, exitExpectation: test1Exit)
+        var state = State(board: Board(), turn: .dark, playerModes: [.manual, .manual])
+        state.phase = AnyPhase(phase)
+        
+        let game = Game(state: state)
+
+        let stateChange = expectation(description: "change of state")
+        game.statePublisher
+            .sink { state in
+                if state.phase.kind == .test2 {
+                    stateChange.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        game.dispatch(action: .start)
+        
+        wait(for: [stateChange, test1Enter, test1Exit], timeout: 3.0)
+    }
+    
+    func testGameStartToNextTurn() {
+        let game = Game()
+        game.makeCurrent()
+
+        let stateSubscriber = EventuallyFulfill<State, Never>()
+        game.statePublisher.subscribe(stateSubscriber)
+        stateSubscriber.store(in: &cancellables)
+
+        // まずはゲーム開始時点のチェック
+        let startingExpectation = expectation(description: "Start")
+        stateSubscriber.reset(startingExpectation, inputChecker: { state in
+            // 両カウントが 2
+            guard state.diskCount[.dark] == 2 else { return false }
+            guard state.diskCount[.light] == 2 else { return false }
+            
+            // 思考中ではない
+            guard !state.thinking else { return false}
+            
+            // というかどちらもManual
+            guard state.playerModes[.dark] == .manual else { return false }
+            guard state.playerModes[.light] == .manual else { return false }
+            
+            // 黒のターン
+            guard state.turn == .dark else { return false }
+            
+            return true
+        })
+        game.dispatch(action: .start)
+        wait(for: [startingExpectation], timeout: 3.0)
+
+        var requestId: UniqueIdentifier = .invalid
+        
+        // --------
+        // --------
+        // --------
+        // ---ox---
+        // ---xo---
+        // --------
+        // --------
+        // --------
+        
+        // 黒を (2, 3) に置いてみる
+        // (2, 3)を黒にする指示が来るまで待つ
+        let dark23Expectation = expectation(description: "Place dark disk on (2, 3)")
+        stateSubscriber.reset(dark23Expectation, inputChecker: { state in
+            if let request = state.boardUpdateRequest {
+                if case let .withAnimation(cellChange) = request.detail {
+                    if cellChange.x == 2 && cellChange.y == 3 && cellChange.disk == .dark {
+                        requestId = request.requestId
+                        return true
+                    }
+                }
+            }
+            return false
+        })
+        game.dispatch(action: .boardCellSelected(x: 2, y: 3))
+        wait(for: [dark23Expectation], timeout: 3.0)
+
+        // --------
+        // --------
+        // --------
+        // --xox---
+        // ---xo---
+        // --------
+        // --------
+        // --------
+        
+        // (2, 3)のアニメーションが終了したことを伝え、
+        // (3, 3)が黒にひっくり返る指示が来るまで待つ
+        let dark33Expectation = expectation(description: "Disk on (3, 3) is flipped")
+        stateSubscriber.reset(dark33Expectation, inputChecker: { state in
+            if let request = state.boardUpdateRequest {
+                if case let .withAnimation(cellChange) = request.detail {
+                    if cellChange.x == 3 && cellChange.y == 3 && cellChange.disk == .dark {
+                        requestId = request.requestId
+                        return true
+                    }
+                }
+            }
+            return false
+        })
+        game.dispatch(action: .boardUpdated(requestId: requestId))
+        wait(for: [dark33Expectation], timeout: 3.0)
+
+        // --------
+        // --------
+        // --------
+        // --xxx---
+        // ---xo---
+        // --------
+        // --------
+        // --------
+
+        // (3, 3)のアニメーションが終了したことを伝えると
+        // 黒のカウントが4, 白のカウントが1になり、白のターンになる
+        let turnChangeExpectation = expectation(description: "Turn change to light")
+        stateSubscriber.reset(turnChangeExpectation, inputChecker: { state in
+            guard state.diskCount[.dark] == 4 else { return false }
+            guard state.diskCount[.light] == 1 else { return false }
+            guard state.turn == .light else { return false }
+            
+            return true
+        })
+        game.dispatch(action: .boardUpdated(requestId: requestId))
+        wait(for: [turnChangeExpectation], timeout: 3.0)
+    }
+    
+    func testGameByComputer() {
+        // 思考時間を短くしておく
+        let originalDuration = ThinkingPhase.thinkingDuration
+        defer { ThinkingPhase.thinkingDuration = originalDuration }
+        ThinkingPhase.thinkingDuration = 0.5
+        
+        let state = State(board: Board(), turn: .dark, playerModes: [.computer, .computer])
+        let game = Game(state: state)
+        game.makeCurrent()
+
+        let stateSubscriber = EventuallyFulfill<State, Never>()
+        let publisher = game
+            .statePublisher
+            .share()
+            
+        publisher.subscribe(stateSubscriber)
+        stateSubscriber.store(in: &cancellables)
+
+        // 画面への表示要求が来たら表示したことにして返すための購読を
+        // 行っておく
+        publisher
+            .compactMap { $0.boardUpdateRequest }
+            .removeDuplicates()
+            .sink { request in
+                game.dispatch(action: .boardUpdated(requestId: request.requestId))
+            }
+            .store(in: &cancellables)
+        
+        // ゲームを開始して、黒のターンで、思考中になるまで待つ
+        let startingExpectation = expectation(description: "Start")
+        stateSubscriber.reset(startingExpectation, inputChecker: { state in
+            // 黒のターン
+            guard state.turn == .dark else { return false }
+
+            // 思考中
+            guard state.thinking else { return false}
+            
+            return true
+        })
+        game.dispatch(action: .start)
+        wait(for: [startingExpectation], timeout: 3.0)
+
+        // 思考中が終わるまで待つ
+        let darkThinkingFinishedExpectation = expectation(description: "Thinking finished (dark)")
+        stateSubscriber.reset(darkThinkingFinishedExpectation, inputChecker: { state in
+            return !state.thinking && state.turn == .dark
+        })
+        wait(for: [darkThinkingFinishedExpectation], timeout: 3.0)
+        
+        // 白のターンで思考中になるまで待つ
+        // その間、画面への表示要求が来たら表示したことにして返す
+        let lightThinkingExpectation = expectation(description: "Thinking (light))")
+        stateSubscriber.reset(lightThinkingExpectation, inputChecker: { state in
+            return state.thinking && state.turn == .light
+        })
+        wait(for: [lightThinkingExpectation], timeout: 3.0)
+    }
 }

--- a/ReversiTests/GameTests.swift
+++ b/ReversiTests/GameTests.swift
@@ -70,7 +70,7 @@ class GameTests: XCTestCase {
             
             return true
         })
-        game.dispatch(.start)
+        game.dispatch(.start())
         wait(for: [startingExpectation], timeout: 3.0)
 
         var requestId: UniqueIdentifier = .invalid
@@ -189,7 +189,7 @@ class GameTests: XCTestCase {
             
             return true
         })
-        game.dispatch(.start)
+        game.dispatch(.start())
         wait(for: [startingExpectation], timeout: 3.0)
 
         // 思考中が終わるまで待つ

--- a/ReversiTests/GameTests.swift
+++ b/ReversiTests/GameTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import Reversi
+
+class GameTests: XCTestCase {
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    
+
+}


### PR DESCRIPTION
ゲームの進行を管理するモデル層のビジネスロジックとして、Redux風のアーキテクチャとそれを使ったゲーム進行を実装しました（ `Game` クラス）。

最終的には、この `Game` がMVVMアーキテクチャのModelに相当する予定です（図の右端）。

<img src="https://user-images.githubusercontent.com/1498691/80898162-38938400-8d3b-11ea-86b0-c3a410871c26.jpg" title="mvvm" width="600">

まだ、ゲーム状態のセーブとロードが実装できていません。また、テストコードも一部しか書いていません。が、一度、このあたりで実装を止めておいて、ViewModelの実装に入ろうと思います。

以下、解説です。


## Redux風アーキテクチャ

### 基本

- 単一の状態（ `State` ）を保持します。
- アクション（ `Action` ）がディスパッチ（ `Dispatcher.dispatch` ）されると、現在の状態とアクションがリデューサー（ `Reducer.reduce` ）に渡されます。リデューサーは新しい状態を戻り値として返し、これによってのみ、保持している状態が更新されます。外部からは `Game.statePublisher` を購読することで状態の変更を通知してもらうことができます。
- リデューサーは同じ引数が与えられたら常に同じ値を返します。また、副作用のある処理（外部にある状態の変更、非同期処理の実行開始など）をこの中に実装してはいけません。

### サンク

非同期処理の結果を受けて処理するような、一連のアクションのディスパッチを可能にするために、サンク（ `Thunk` ）をディスパッチすることができるようになっています。

サンクはディスパッチャーと現在の状態を引数にとる普通の関数で、この中では副作用の発生する処理を実装しても構いません。

実装イメージ：

```swift
let game = Game()
game.dispatch(.thunk({ (dispatcher, state) in
    // このときのstateの状態を確認して処理できる
    guard state.isFooNeeded else { return }

    // 開始状態に変更するアクションをディスパッチ
    dispatcher.dispatch(.action(.startFoo))
    // 非同期処理を開始（結果がクロージャーで返されるとする）
    fooAsync(state.requestedFoo) { result in
        // 非同期処理の結果を反映するアクションをディスパッチ
        dispatcher.dispatch(.action(.endFoo(result)))
    }
}))
```

※実際には `State.isFooNeeded` や `Action.startFoo` などは存在しません。

### ループ

リデューサーがアクションを適用した結果、非同期実行を開始したい場合のために、 `State.loop` にサンクを渡して呼び出すと、状態が更新されたあとに、そのサンクがディスパッチされます。

実装イメージ：

```swift
static func reduce(state: State, action: Action) -> State {
    var state = state

    switch action {
    case .bar(let id):
        state.barId = barId
        // あとで実行して欲しいサンクを積む
        state.loop { (dispatcher, state) in
            // ここはサンクなので、非同期実行を開始してもよい
            barAsync(state.barId) { result in
                // 非同期処理の結果を反映するアクションをディスパッチ
                dispatcher.dispatch(.action(.barResult(result)))
            }
        }
    }

    return state
}
```

※実際には `State.barId` や `Action.barResult` などは存在しません。


## フェーズ

状態の中にフェーズ（ `State.phase` ）があり、これがゲームの進行状況を表しています。
フェーズは `Phase` プロトコルに準拠した値で、フェーズ固有の変数を状態として保持することもできます。また、 `Phase` に準拠した型はリデューサーとしての役割も持っており、
メインのリデューサーの中から、そのときのフェーズ（ `State.phase` ）の型のリデューサーが呼び出されます。ここでフェーズ固有のアクションをハンドリングできます。

フェーズは、 `onEnter` 、 `onExit` という、サンクを返すことのできる `static` 関数を提供します。それぞれ、別のフェーズからこのフェーズに変わった直後、このフェーズから別のフェーズへ変わる直前に呼び出され、フェーズ遷移のタイミングで処理を行えるようになっています。

<img src="https://user-images.githubusercontent.com/1498691/80898170-56f97f80-8d3b-11ea-89cc-cc60f5821bac.jpg" title="phases" width="432">

## 外部（View側）への依頼

アニメーションや、アラートの表示といった、UI側の操作を伴うものは、 `State` の中に `xxxxRequest` という名前の `Optional` のプロパティを持っています。これが値を持っている時は、「外部に依頼を出している状態」という意味になります。

例：

```swift
/// リバーシ盤の表示を更新する依頼が出ていれば値が設定されています。
/// 依頼に答えたら `Actionish.boardUpdated()` の結果をディスパッチしてください。
public var boardUpdateRequest: DetailedRequest<BoardUpdate>?

/// 「パス」を通知する依頼が出ていれば値が設定されています。
/// 依頼に答えて通知が閉じられたら `Actionish.passDismissed()` の結果をディスパッチしてください。
public var passNotificationRequest: Request?
```

UI側では、この依頼に応じてUIを制御し、アニメーション終了時やアラートが閉じられた時に、それに相当するアクションをディスパッチします。
