### PR TITLE
Storeがサンクやループを扱うときにGameでdispatchしていなかった不具合を修正

### DIFF
--- a/Reversi/Action.swift
+++ b/Reversi/Action.swift
@@ -7,6 +7,15 @@ public enum Actionish {
     
     /// アクションを遅延ディスパッチするサンクです。
     case thunk(Thunk)
+
+    /// 実際のアクションなら `true` になります。
+    public var isAction: Bool {
+        if case .action(_) = self {
+            return true
+        } else {
+            return false
+        }
+    }
 }
 
 // 外部からディスパッチしてもらうもの
@@ -116,7 +125,7 @@ extension Actionish {
 }
 
 /// ゲームの状態を進めるためのアクションです。
-public enum Action {
+public enum Action: CustomStringConvertible {
     /// ゲームを開始するときにディスパッチするアクションです。
     case start
     
@@ -161,4 +170,45 @@ public enum Action {
     
     /// リセットを実行するアクションです。
     case doReset
+    
+    public var description: String {
+        switch self {
+        case .start:
+            return "start"
+        case .boardCellSelected(x: let x, y: let y):
+            return "boardCellSelected(x: \(x), y: \(y))"
+        case .playerModeChanged(player: let player, mode: let mode):
+            return "playerModeChanged(player: \(player), mode: \(mode))"
+        case .reset:
+            return "reset"
+        case .resetConfirmed(requestId: let requestId, execute: let execute):
+            return "resetConfirmed(requestId: \(requestId), execute: \(execute))"
+        case .passDismissed(requestId: let requestId):
+            return "passDismissed(requestId: \(requestId))"
+        case .boardUpdated(requestId: let requestId):
+            return "boardUpdated(requestId: \(requestId))"
+        case .changePhase(nextPhase: let nextPhase):
+            return "changePhase(nextPhase: \(nextPhase))"
+        case .initializeStateWhenStarted:
+            return "initializeStateWhenStarted"
+        case .setThinking(let thinking):
+            return "setThinking(\(thinking))"
+        case .placeDisk(disk: let disk, x: let x, y: let y):
+            return "placeDisk(disk: \(disk), x: \(x), y: \(y))"
+        case .requestUpdateBoard(request: let request):
+            let requestText: String
+            if let request = request {
+                requestText = "\(request)"
+            } else {
+                requestText = "nil"
+            }
+            return "requestUpdateBoard(request: \(requestText))"
+        case .requestPassNotification(let doRequest):
+            return "requestPassNotification(\(doRequest))"
+        case .nextTurn:
+            return "nextTurn"
+        case .doReset:
+            return "doReset"
+        }
+    }
 }

--- a/Reversi/Game.swift
+++ b/Reversi/Game.swift
@@ -7,7 +7,7 @@ public enum GameError: Error {
 
 /// ゲームの状態を保持し、アクションをディスパッチすることでゲームを進めます。
 public class Game: Dispatcher {
-    private let store: Store
+    private lazy var store: Store = { () -> Store in fatalError() }()
 
     /// 現在の状態
     public var state: State {
@@ -15,7 +15,7 @@ public class Game: Dispatcher {
     }
     
     /// 現在の状態が変更されたときのイベント発行者
-    public let statePublisher: AnyPublisher<State, Never>
+    public lazy var statePublisher: AnyPublisher<State, Never> = { () -> AnyPublisher<State, Never> in fatalError() }()
 
     /// 状態を変更するもの
     public lazy var dispatcher: Dispatcher = { () -> Dispatcher in fatalError() }()
@@ -26,7 +26,7 @@ public class Game: Dispatcher {
                                      playerModes: [.manual, .manual]),
                 reducer: Reducer.Type = GameReducer.self,
                 middlewares: [Middleware.Type] = []) {
-        store = Store(initialState: state, reducer: reducer)
+        store = Store(rootDispatcher: self, initialState: state, reducer: reducer)
         statePublisher = store.stateHolder
             .eraseToAnyPublisher()
         dispatcher = middlewares.reversed().reduce(store) { (next, middleware) in

--- a/Reversi/Logger.swift
+++ b/Reversi/Logger.swift
@@ -4,6 +4,7 @@ import Foundation
 public class Logger: Middleware, Dispatcher {
     private let game: Game
     private let next: Dispatcher
+    private var depth = 0
     
     public init(game: Game, next: Dispatcher) {
         self.game = game
@@ -14,9 +15,21 @@ public class Logger: Middleware, Dispatcher {
         return Logger(game: game, next: next)
     }
 
+    private var indent: String {
+        return String(repeating: " ", count: depth * 2)
+    }
+    
     public func dispatch(_ actionish: Actionish) {
-        print("(Phase: \(game.state.phase),\n Action: \(actionish))")
-        next.dispatch(actionish)
-        print("  --> Phase: \(game.state.phase)")
+        guard actionish.isAction else {
+            next.dispatch(actionish)
+            return
+        }
+        
+        print("\(indent)Phase: \(game.state.phase), Action: \(actionish)")
+        do {
+            depth += 1; defer { depth -= 1 }
+            next.dispatch(actionish)
+        }
+        print("\(indent)----> Phase: \(game.state.phase)")
     }
 }

--- a/Reversi/State.swift
+++ b/Reversi/State.swift
@@ -53,13 +53,17 @@ public struct State {
 }
 
 /// ゲーム外部に出す依頼
-public struct Request: Hashable {
+public struct Request: Hashable, CustomStringConvertible {
     /// 依頼の番号
     public let requestId = UniqueIdentifier()
+    
+    public var description: String {
+        return "Request(requestId: \(requestId))"
+    }
 }
 
 /// ゲーム外部に出す依頼（詳細付き）
-public struct DetailedRequest<D: Hashable>: Hashable {
+public struct DetailedRequest<D: Hashable>: Hashable, CustomStringConvertible {
     /// 依頼の番号
     public let requestId = UniqueIdentifier()
     
@@ -69,14 +73,27 @@ public struct DetailedRequest<D: Hashable>: Hashable {
     public init(_ detail: D) {
         self.detail = detail
     }
+    
+    public var description: String {
+        return "Request(requestId: \(requestId), detail: \(detail))"
+    }
 }
 
 /// リバーシ盤の表示更新の依頼内容
-public enum BoardUpdate: Hashable {
+public enum BoardUpdate: Hashable, CustomStringConvertible {
     /// 「1つのセルをアニメーション付きで更新してください」という依頼
     case withAnimation(Board.CellChange)
     
     /// 「一連のセルをアニメーションなしで更新してください」という依頼
     case withoutAnimation([Board.CellChange])
+    
+    public var description: String {
+        switch self {
+        case .withAnimation(let change):
+            return "withAnimation(\(change))"
+        
+        case .withoutAnimation(let changes):
+            return "withoutAnimation(\(changes))"
+        }
+    }
 }
-

--- a/Reversi/UniqueIdentifier.swift
+++ b/Reversi/UniqueIdentifier.swift
@@ -15,7 +15,7 @@ public struct UniqueIdentifier: Hashable, CustomStringConvertible {
     }
     
     public var description: String {
-        return "ID:\(rawValue)"
+        return "ID=\(rawValue)"
     }
     
     public static let invalid = UniqueIdentifier(rawValue: 0)


### PR DESCRIPTION
サンクやループがディスパッチされるときに、ミドルウェアを通っておらず、 `Logger` に出力されなかった不具合を修正しました。

また、出力されるようになると、ログが非常に見辛かったので、少しでも見やすくなるように修正しました。