### PR TITLE
勝敗決定がセーブされない不具合の修正

### DIFF
--- a/Reversi/GameOverPhase.swift
+++ b/Reversi/GameOverPhase.swift
@@ -20,6 +20,9 @@ public struct GameOverPhase: Phase {
         switch action {
         case .gameOver:
             state.turn = nil
+            state.loop { (dispatcher, _) in
+                dispatcher.dispatch(.requestSave())
+            }
             
         default:
             break

--- a/Reversi/NextTurnPhase.swift
+++ b/Reversi/NextTurnPhase.swift
@@ -14,6 +14,9 @@ public struct NextTurnPhase: Phase {
     }
     
     public static func onExit(nextPhase: AnyPhase) -> Thunk? {
+        // 次がGameOverの場合はそちらでセーブ依頼を出してもらう
+        guard nextPhase.kind != .gameOver else { return nil }
+        
         return { (dispatcher, _) in
             dispatcher.dispatch(.requestSave())
         }

--- a/ReversiTests/GameOverPhaseTests.swift
+++ b/ReversiTests/GameOverPhaseTests.swift
@@ -44,9 +44,13 @@ class GameOverPhaseTests: XCTestCase {
         let gameState = game.statePublisher.share()
 
         // ターンがnilに変わる
-        let expectTurnChange = expectation(description: "Turn changed to nil")
+        // セーブ依頼も出る
+        let expectTurnChange = expectation(description: "Turn changed to nil and save requested")
         let stateSubscriber = EventuallyFulfill<State, Never>(expectTurnChange, inputChecker: { state in
-            return state.turn == nil
+            guard state.turn == nil else { return false }
+            guard state.saveRequest != nil else { return false }
+            
+            return true
         })
         gameState.subscribe(stateSubscriber)
         stateSubscriber.store(in: &cancellables)


### PR DESCRIPTION
fixes #9 

GameOverフェーズに移行したときは、 `turn` を `nil` にしたあとでセーブ依頼を出すようにしました。
また、NextTurnフェーズからGameOverフェーズに移行するタイミングではセーブ依頼は出さないようにしました。