### PR TITLE
テスト実行のための起動中はゲームをスタートさせないようにした

### DIFF
--- a/Reversi/ViewModel.swift
+++ b/Reversi/ViewModel.swift
@@ -122,6 +122,10 @@ class ViewModel {
     
     /// ビューが初めて表示されたときに呼び出します。
     func viewDidFirstAppear() {
+        // テスト実行のときはゲームをスタートさせない
+        let isTestRunning = ProcessInfo.processInfo.environment["XCInjectBundleInto"] != nil
+        guard !isTestRunning else { return }
+        
         game.dispatch(.start())
     }
     


### PR DESCRIPTION
テスト実行中のログにまざって、アプリで動いているゲームのログが出て混乱するので。